### PR TITLE
Match upstream

### DIFF
--- a/examples/hello/src/hello/app.nix
+++ b/examples/hello/src/hello/app.nix
@@ -5,6 +5,7 @@ inputs.nixpkgs.stdenv.mkDerivation
   rec {
     pname = "hello";
     version = "2.10";
+    doCheck = true;
     src =
       inputs.nixpkgs.fetchurl
         {


### PR DESCRIPTION
With doCheck enabled, the default package is likely to be built/cached by
cache.nixos.org already.