### PR TITLE
tui: Tear down UI on loading error

### DIFF
--- a/cells/std/cli/main.go
+++ b/cells/std/cli/main.go
@@ -1,10 +1,9 @@
 package main
 
 import (
-	"fmt"
+	"log"
 
 	"math/rand"
-	"os"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -13,8 +12,9 @@ import (
 func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
 
-	if err := tea.NewProgram(InitialPage()).Start(); err != nil {
-		fmt.Println("Error running program:", err)
-		os.Exit(1)
+	if model, err := tea.NewProgram(InitialPage()).StartReturningModel(); err != nil {
+		log.Fatalf("Error running program: %s", err)
+	} else if err := model.(*Tui).FatalError; err != nil {
+		log.Fatal(err)
 	}
 }

--- a/cells/std/cli/tui.go
+++ b/cells/std/cli/tui.go
@@ -45,6 +45,7 @@ type Tui struct {
 	Spinner      spinner.Model
 	Loading      bool
 	Error        string
+	FatalError   error
 	Focus
 	Width  int
 	Height int
@@ -76,6 +77,10 @@ func (m *Tui) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case exitErrMsg:
 		m.Error = msg.Error()
 		return m, nil
+
+	case fatalErrMsg:
+		m.FatalError = msg.err
+		return m, tea.Quit
 
 	case models.ActionInspectMsg:
 		m.InspecAction = string(msg)


### PR DESCRIPTION
Replace log.Fatal when fatal loading error occurs with propagating error
to main() so that Bubbletea can properly tear down UI and restore
terminal to its original state. Output the error after it's done.