### PR TITLE
Avoid multiple eval of `grow args` in `growOn`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,14 +22,11 @@
     deSystemize = import ./src/de-systemize.nix;
     grow = import ./src/grow.nix {inherit (inputs) nixpkgs yants;};
 
-    growOn = args: soil:
-      l.attrsets.recursiveUpdate (
-        soil
-        // {
-          __functor = self: soil':
-            growOn args (l.recursiveUpdate soil' self);
-        }
-      ) (grow args);
+    growOn = args:
+      grow args
+      // {
+        __functor = l.flip l.recursiveUpdate;
+      };
     harvest = t: p:
       l.mapAttrs (_: v: l.getAttrFromPath p v)
       (


### PR DESCRIPTION
 when there is more than one layer of soil.

 Note that this should also allow to merge `grow` and `growOn`
 into a single function if so desired.