### PR TITLE
Don't overwrite flake's nixpkgs input

### DIFF
--- a/src/grow.nix
+++ b/src/grow.nix
@@ -132,16 +132,18 @@
       args.inputs = _debug "inputs on ${system}" (
         (deSystemize system inputs)
         // {
-          nixpkgs = import nixpkgs {
-            localSystem = system;
-            config = builtinNixpkgsConfig // nixpkgsConfig;
-          };
           self =
             inputs.self.sourceInfo
             // {rev = inputs.self.sourceInfo.rev or "not-a-commit";};
           cells =
             # recursion on cells
             deSystemize system res.output;
+        }
+        // l.optionalAttrs (inputs ? nixpkgs) {
+          nixpkgs = import inputs.nixpkgs {
+            localSystem = system;
+            config = builtinNixpkgsConfig // nixpkgsConfig;
+          };
         }
       );
       loadCellFor = cellName: let


### PR DESCRIPTION
std used to overwrite nixpkgs input with its own even if it's provided.
Switch to adding nixpkgs input only if it is provided by flake and only with the one provided by flake.