### PR TITLE
fix syntax error of data expo

### DIFF
--- a/src/clades.nix
+++ b/src/clades.nix
@@ -114,12 +114,12 @@ in {
       {
         name = "write";
         description = "write to file";
-        command = l.concatStringsSep "\n" (builder ++ jq);
+        command = l.concatStringsSep "\t" (builder ++ jq);
       }
       {
         name = "explore";
         description = "interactively explore";
-        command = l.concatStringsSep "\n" (builder ++ jq ++ fx);
+        command = l.concatStringsSep "\t" (builder ++ jq ++ fx);
       }
     ];
   };


### PR DESCRIPTION
Does the `\n` work on your system?

- the issue output:

```
  > /nix/store/llj15iriibhfibss9jy46fpk6ss1kwfh-explore: line 17: syntax error near unexpected token `|'  
  > /nix/store/llj15iriibhfibss9jy46fpk6ss1kwfh-explore: line 17: `|'
```