### PR TITLE
fix mdbook-krioki command

### DIFF
--- a/cells/std/devshellProfiles.nix
+++ b/cells/std/devshellProfiles.nix
@@ -55,7 +55,7 @@ in {
         build-dir = "docs/book"
 
         [preprocessor.kroki-preprocessor]
-        command = "${kroki-preprocessor}"
+        command = "${kroki-preprocessor}/bin/mdbook-kroki-preprocessor"
 
         EOF
         cat << EOF > docs/SUMMARY.md


### PR DESCRIPTION
It seems we can not render the table/list when mdbook-kriki enabled.