### PR TITLE
imp: add standardized writeShellEntrypoint

### DIFF
--- a/cells/std/lib/default.nix
+++ b/cells/std/lib/default.nix
@@ -109,4 +109,16 @@ in {
     l.customisation.callPackageWith makes;
 
   fromMicrovmWith = import ./fromMicrovmWith.nix {inherit nixpkgs;};
+
+  writeShellEntrypoint = inputs': let
+    inputsChecked = assert nixpkgs.lib.assertMsg (builtins.hasAttr "n2c" inputs') (
+      nixpkgs.lib.traceSeqN 1 inputs' ''
+
+        In order to be able to use 'std.std.lib.writeShellEntrypoint', an input
+        named 'n2c' (representing 'nlewo/nix2container') must be defined in the flake.
+        See inputs above.
+      ''
+    ); inputs';
+  in
+    import ./writeShellEntrypoint.nix { inputs = inputsChecked; inherit cell;};
 }

--- a/cells/std/lib/writeShellEntrypoint.md
+++ b/cells/std/lib/writeShellEntrypoint.md
@@ -43,6 +43,7 @@ The following contracts can be consumed:
 
 ```
 /bin/entrypoint # always present
+/bin/runtime    # always present, drops into the runtime environment
 /bin/live       # if livenessProbe was set
 /bin/ready      # if readinessProbe was set
 ```
@@ -63,6 +64,7 @@ The following contracts can be consumed:
 
 ```
 /bin/entrypoint # always present
+/bin/runtime    # always present, drops into the runtime environment
 /bin/debug      # always present, drops into the debugging environment
 /bin/live       # if livenessProbe was set
 /bin/ready      # if readinessProbe was set

--- a/cells/std/lib/writeShellEntrypoint.md
+++ b/cells/std/lib/writeShellEntrypoint.md
@@ -1,0 +1,105 @@
+# `writeShellEntrypoint`
+
+... is a function to write Standard OCI-image entrypoints.
+
+The function signature is as follows:
+
+```nix
+{
+  # the installable that is wrapped by this entrypoint (re-exported)
+  package,
+  # the literal bash string of the entrypoint that will be wrapped
+  entrypoint,
+  # initialize environment variables with these defaults
+  env ? {},
+  # runtime installables that the entrypoint or liveness/readiness probe uses (re-exported)
+  runtimeInputs ? [],
+  # domain specific debugging utilities (re-exported)
+  debugInputs ? [],
+  # domain specific liveness probe literal bash fragment (re-exported)
+  livenessProbe ? null,
+  # domain specific readiness probe literal bash fragment (re-exported)
+  readinessProbe ? null,
+}
+```
+
+It's output wraps utility functions to generate size-optimized OCI-images:
+
+```nix
+rec {
+  entrypoint = std.std.lib.writeShellEntrypoint inputs { /* ... */ };
+  oci-image = entrypoint.mkOCI "docker.io/my-oci-image";
+  oci-debug-image = entrypoint.mkDebugOCI "docker.io/my-oci-image-debug";
+}
+```
+
+## The Standard Image
+
+Standard images are minimal and hardened. They only contain required dependencies.
+
+### Contracts
+
+The following contracts can be consumed:
+
+```
+/bin/entrypoint # always present
+/bin/live       # if livenessProbe was set
+/bin/ready      # if readinessProbe was set
+```
+
+That's it. There is nothing more to see.
+
+All other dependencies are contained in `/nix/store/...`.
+
+## The Debug Image
+
+Debug Images wrap the standard images and provide additional debugging packages.
+
+Hence, they are neither minimal, nor hardened because of the debugging packages' added surface.
+
+### Contracts
+
+The following contracts can be consumed:
+
+```
+/bin/entrypoint # always present
+/bin/debug      # always present, drops into the debugging environment
+/bin/live       # if livenessProbe was set
+/bin/ready      # if readinessProbe was set
+```
+
+## How to extend?
+
+A Standard or Debug Image doesn't have a package manager available in the environment.
+
+Hence, to extend the image you have two options:
+
+### Nix-based extension
+
+```nix
+rec {
+  upstream = n2c.pullImage {
+    imageName = "docker.io/my-upstream-image";
+    imageDigest = "sha256:fffff.....";
+    sha256 = "sha256-ffffff...";
+  };
+  modified = n2c.buildImage {
+    name = "docker.io/my-modified-image";
+    fromImage = upstream;
+    contents = [nixpkgs.bashInteractive];
+  };
+}
+```
+
+### Dockerfile-based extension
+
+```Dockerfile
+FROM alpine AS builder
+RUN apk --no-cache curl
+
+FROM docker.io/my-upstream-image
+COPY --from=builder /... /
+
+```
+
+_Please refer to the official dockerfile documentation for more details._

--- a/cells/std/lib/writeShellEntrypoint.nix
+++ b/cells/std/lib/writeShellEntrypoint.nix
@@ -27,6 +27,8 @@
       ++ (l.optional (entrypoint.livenessProbe != null) entrypoint.livenessProbe)
       ++ (l.optional (entrypoint.readinessProbe != null) entrypoint.readinessProbe);
     config.Cmd = ["${entrypoint}/bin/entrypoint"];
+    config.User = "65534"; # nobody
+    config.Group = "65534"; # nogroup
     config.Labels =
       (l.optionalAttrs (entrypoint.package ? src) {
         "org.opencontainers.image.source" = "file://${l.unsafeDiscardStringContext entrypoint.package.src}";

--- a/cells/std/lib/writeShellEntrypoint.nix
+++ b/cells/std/lib/writeShellEntrypoint.nix
@@ -130,10 +130,10 @@
       ${l.optionalString (nixpkgs.stdenv.hostPlatform.libc == "glibc") "export LOCALE_ARCHIVE=${locales}/lib/locale/locale-archive"}
       ${l.concatStringsSep "\n" (l.mapAttrsToList (n: v: "export ${n}=${''"$''}{${n}:-${toString v}}${''"''}") env)}
     '';
-    checkPhase = ''
+    checkPhase' = path: ''
       runHook preCheck
-      ${nixpkgs.stdenv.shell} -n $out/bin/entrypoint
-      ${nixpkgs.shellcheck}/bin/shellcheck $out/bin/entrypoint
+      ${nixpkgs.stdenv.shell} -n $out/${path}
+      ${nixpkgs.shellcheck}/bin/shellcheck $out/${path}
       runHook postCheck
     '';
     live =
@@ -143,7 +143,7 @@
           name = "live";
           executable = true;
           destination = "/bin/live";
-          inherit checkPhase;
+          checkPhase = checkPhase' "/bin/live";
           text = ''
             ${prelude}
 
@@ -158,7 +158,7 @@
           name = "ready";
           executable = true;
           destination = "/bin/ready";
-          inherit checkPhase;
+          checkPhase = checkPhase' "/bin/ready";
           text = ''
             ${prelude}
 
@@ -170,7 +170,7 @@
       name = "runtime";
       executable = true;
       destination = "/bin/runtime";
-      inherit checkPhase;
+      checkPhase = checkPhase' "/bin/runtime";
       text = prelude;
     };
     inner =
@@ -178,7 +178,7 @@
         name = "entrypoint";
         executable = true;
         destination = "/bin/entrypoint";
-        inherit checkPhase;
+        checkPhase = checkPhase' "/bin/entrypoint";
         text = ''
           ${prelude}
 

--- a/cells/std/lib/writeShellEntrypoint.nix
+++ b/cells/std/lib/writeShellEntrypoint.nix
@@ -1,0 +1,209 @@
+{
+  inputs,
+  cell,
+}: let
+  inherit (inputs) nixpkgs;
+  l = nixpkgs.lib // builtins;
+  n2c = inputs.n2c.packages.nix2container;
+
+  stdImageDocs = "https://divnix.github.io/std/reference/std/lib/writeShellEntrypoint.html";
+  locales = nixpkgs.glibcLocales.override {allLocales = false;};
+
+  mkOCI = entrypoint: name: {
+    inherit name;
+    layers = [
+      (n2c.buildLayer {
+        deps = entrypoint.runtimeInputs;
+        maxLayers = 10;
+      })
+      # dependencies
+      (n2c.buildLayer {
+        deps = [entrypoint.package];
+        maxLayers = 90;
+      })
+    ];
+    contents =
+      []
+      ++ (l.optional (entrypoint.livenessProbe != null) entrypoint.livenessProbe)
+      ++ (l.optional (entrypoint.readinessProbe != null) entrypoint.readinessProbe);
+    config.Cmd = ["${entrypoint}/bin/entrypoint"];
+    config.Labels =
+      (l.optionalAttrs (entrypoint.package ? src) {
+        "org.opencontainers.image.source" = "file://${l.unsafeDiscardStringContext entrypoint.package.src}";
+      })
+      // (l.optionalAttrs (entrypoint.package.meta ? description) {
+        "org.opencontainers.image.description" = entrypoint.package.meta.description;
+      })
+      // (l.optionalAttrs (entrypoint.package.meta ? license && entrypoint.package.meta.license ? spdxId) {
+        "org.opencontainers.image.licenses" = entrypoint.package.meta.license.spdxId;
+      })
+      // {
+        "org.opencontainers.image.url" = stdImageDocs;
+        "org.opencontainers.image.version" = l.getVersion entrypoint.package;
+        "org.opencontainers.image.title" = "Standard Image for ${l.getName entrypoint.package}";
+      };
+  };
+
+  mkDebugOCI = entrypoint: name: let
+    debug-banner = nixpkgs.runCommandNoCC "debug-banner" {} ''
+      ${nixpkgs.figlet}/bin/figlet -f banner "STD Debug" > $out
+    '';
+    debug-tools = with nixpkgs.pkgsStatic; [busybox];
+    debug-bin = nixpkgs.writeShellApplication {
+      name = "debug";
+      runtimeInputs =
+        (entrypoint.runtimeInputs or [])
+        ++ entrypoint.debugInputs or []
+        ++ debug-tools;
+      text = ''
+        # shellcheck source=/dev/null
+        # source ''${cacert}/nix-support/setup-hook
+
+        cat ${debug-banner}
+        echo
+        echo "=========================================================="
+        echo "This debug shell contains the runtime environment and "
+        echo "debug dependencies of the entrypoint."
+        echo "To inspect the entrypoint(s) run:"
+        echo "cat ${entrypoint}/bin/*"
+        echo "=========================================================="
+        echo
+        exec bash "$@"
+      '';
+    };
+    oci = mkOCI entrypoint name;
+  in
+    oci
+    // {
+      layers =
+        (oci.layers or [])
+        ++ [
+          # prepare a special layer that bundles all generic debugging packages
+          (n2c.buildLayer {
+            deps = debug-tools ++ [debug-banner];
+            maxLayers = 1;
+          })
+          # prepare a special layer that bundles the relatively stable extra debugging packages
+          (n2c.buildLayer {
+            deps = entrypoint.debugInputs;
+            maxLayers = 4;
+          })
+        ];
+      contents = (oci.contents or []) ++ [debug-bin];
+      config =
+        oci.config
+        // {
+          Labels =
+            oci.config.Labels
+            // {
+              "org.opencontainers.image.title" = "Debug Image for ${l.getName entrypoint.package}";
+            };
+        };
+    };
+
+  entrypoint = {
+    # the installable that is wrapped by this entrypoint (re-exported)
+    package,
+    # the bash litteral string of the entrypoint
+    entrypoint,
+    # initialize environment variables with these defaults
+    env ? {},
+    # runtime installables that the entrypoint or liveness/readiness probe uses (re-exported)
+    runtimeInputs ? [],
+    # domain specific debugging utilities (re-exported)
+    debugInputs ? [],
+    # domain specific liveness probe (re-exported)
+    livenessProbe ? null,
+    # domain specific readiness probe (re-exported)
+    readinessProbe ? null,
+  }: let
+    prelude = ''
+      #!${nixpkgs.pkgsStatic.bash.out}/bin/bash
+      set -o errexit
+      set -o nounset
+      set -o pipefail
+
+      export PATH="${l.makeBinPath runtimeInputs}:$PATH"
+
+      ${l.optionalString (nixpkgs.stdenv.hostPlatform.libc == "glibc") "export LOCALE_ARCHIVE=${locales}/lib/locale/locale-archive"}
+      ${l.concatStringsSep "\n" (l.mapAttrsToList (n: v: "export ${n}=${''"$''}{${n}:-${toString v}}${''"''}") env)}
+    '';
+    checkPhase = ''
+      runHook preCheck
+      ${nixpkgs.stdenv.shell} -n $out/bin/entrypoint
+      ${nixpkgs.shellcheck}/bin/shellcheck $out/bin/entrypoint
+      runHook postCheck
+    '';
+    live =
+      if livenessProbe != null
+      then
+        nixpkgs.writeTextFile {
+          name = "live";
+          executable = true;
+          destination = "/bin/live";
+          inherit checkPhase;
+          text = ''
+            ${prelude}
+
+            ${livenessProbe}
+          '';
+        }
+      else null;
+    ready =
+      if readinessProbe != null
+      then
+        nixpkgs.writeTextFile {
+          name = "ready";
+          executable = true;
+          destination = "/bin/ready";
+          inherit checkPhase;
+          text = ''
+            ${prelude}
+
+            ${readinessProbe}
+          '';
+        }
+      else null;
+    inner =
+      nixpkgs.writeTextFile {
+        name = "entrypoint";
+        executable = true;
+        destination = "/bin/entrypoint";
+        inherit checkPhase;
+        text = ''
+          ${prelude}
+
+          sleep "''${DEBUG_SLEEP:-0}"
+          ${entrypoint}
+        '';
+        meta = {
+          mainProgram = "entrypoint";
+          description = "Standard entrypoint for ${l.getName package}";
+        };
+      }
+      // {
+        # include runtimeShell as input data for image layer optimization
+        runtimeInputs =
+          runtimeInputs
+          ++ [nixpkgs.pkgsStatic.bash.out]
+          ++ (l.optional (nixpkgs.stdenv.hostPlatform.libc == "glibc") locales);
+        livenessProbe = live;
+        readinessProbe = ready;
+        inherit debugInputs package live ready;
+      };
+  in
+    inner
+    // {
+      mkOCI = name: n2c.buildImage (mkOCI inner name);
+      mkDebugOCI = name: n2c.buildImage (mkDebugOCI inner name);
+      inherit
+        (inner)
+        package
+        runtimeInputs
+        debugInputs
+        livenessProbe
+        readinessProbe
+        ;
+    };
+in
+  entrypoint

--- a/cells/std/lib/writeShellEntrypoint.nix
+++ b/cells/std/lib/writeShellEntrypoint.nix
@@ -23,7 +23,7 @@
       })
     ];
     contents =
-      []
+      [entrypoint.runtime]
       ++ (l.optional (entrypoint.livenessProbe != null) entrypoint.livenessProbe)
       ++ (l.optional (entrypoint.readinessProbe != null) entrypoint.readinessProbe);
     config.Cmd = ["${entrypoint}/bin/entrypoint"];
@@ -164,6 +164,13 @@
           '';
         }
       else null;
+    runtime = nixpkgs.writeTextFile {
+      name = "runtime";
+      executable = true;
+      destination = "/bin/runtime";
+      inherit checkPhase;
+      text = prelude;
+    };
     inner =
       nixpkgs.writeTextFile {
         name = "entrypoint";
@@ -189,7 +196,7 @@
           ++ (l.optional (nixpkgs.stdenv.hostPlatform.libc == "glibc") locales);
         livenessProbe = live;
         readinessProbe = ready;
-        inherit debugInputs package live ready;
+        inherit debugInputs package live ready runtime;
       };
   in
     inner

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -47,6 +47,7 @@
   - [`/lib`](reference/std/lib/Readme.md)
     - [`/fromMakesWith`](reference/std/lib/fromMakesWith.md)
     - [`/mkShell`](reference/std/lib/mkShell.md)
+    - [`/writeShellEntrypoint`](reference/std/lib/writeShellEntrypoint.md)
     - [`/mkNixago`](reference/std/lib/mkNixago.md)
   - [`/nixago`](reference/std/nixago/Readme.md)
     - [`/adrgen`](reference/std/nixago/adrgen.md)

--- a/docs/reference/std/lib/writeShellEntrypoint.md
+++ b/docs/reference/std/lib/writeShellEntrypoint.md
@@ -1,0 +1,1 @@
+../../../../cells/std/lib/writeShellEntrypoint.md


### PR DESCRIPTION
- implemets an interface to produce OCI-images with the following
  contracts:

```
/bin/entrypoint
/bin/debug
/bin/live
/bin/ready

```
