### PR TITLE
direnv: fix for darwin

### DIFF
--- a/direnv_lib.sh
+++ b/direnv_lib.sh
@@ -20,8 +20,7 @@ use_std() {
   local system
   system="$(nix eval --raw --impure --expr builtins.currentSystem)"
   local cellsroot="$1"
-  local -a frgmnts
-  mapfile -d " " -t frgmnts < <(echo -n "$2" | sed 's#//##' | sed 's#:# #' | sed 's#/# #g')
+  local frgmnts=($(echo "$2" | sed 's#//##' | sed 's#:# #' | sed 's#/# #g'))
   local clade="${frgmnts[0]}"
   local organ="${frgmnts[1]}"
   local target="${frgmnts[2]}"


### PR DESCRIPTION
When I made the suggested shellcheck change I didn't realize that mapfile was incompatible with the default version of Bash (v3) running on OSX.

In this case I think it is more important to optimize for UX of developers on a highly popular OS than it is to cover every recommended lint extensively.