### PR TITLE
devshell: Fix for Darwin

### DIFF
--- a/.github/workflows/nix-darwin.yaml
+++ b/.github/workflows/nix-darwin.yaml
@@ -28,3 +28,6 @@ jobs:
 
     - name: Check std data clade
       run: nix develop --show-trace --print-build-logs .#devShells.x86_64-darwin.checks --command clade-data
+
+    - name: Check default devshell
+      run: nix develop --show-trace --print-build-logs .#devShells.x86_64-darwin.default --command echo OK

--- a/.github/workflows/nix-linux.yaml
+++ b/.github/workflows/nix-linux.yaml
@@ -29,3 +29,6 @@ jobs:
 
     - name: Check std data clade
       run: nix develop --show-trace --print-build-logs .#devShells.x86_64-linux.checks --command clade-data
+
+    - name: Check default devshell
+      run: nix develop --show-trace --print-build-logs .#devShells.x86_64-linux.default --command echo OK

--- a/cells/std/packages.nix
+++ b/cells/std/packages.nix
@@ -2,7 +2,7 @@
   inputs,
   cell,
 }: {
-  adrgen = inputs.nixpkgs.adrgen;
+  adrgen = inputs.nixpkgs.callPackage ./packages/adrgen.nix {};
   mdbook = inputs.nixpkgs.mdbook;
   mdbook-kroki-preprocessor = import ./packages/mdbook-kroki-preprocessor.nix {inherit inputs cell;};
 }

--- a/cells/std/packages/adrgen.nix
+++ b/cells/std/packages/adrgen.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  testers,
+  adrgen,
+}:
+buildGoModule rec {
+  pname = "adrgen";
+  version = "2022-08-08";
+
+  src = fetchFromGitHub {
+    owner = "asiermarques";
+    repo = "adrgen";
+    rev = "20fe6e72f354f0fc5248522d7cdd10cb427ada29";
+    sha256 = "sha256-orZPkqPPM3XlzNRDlR9+qv4ntdcmvVnRL9vkx84IZO0=";
+  };
+
+  vendorSha256 = "sha256-RXwwv3Q/kQ6FondpiUm5XZogAVK2aaVmKu4hfr+AnAM=";
+
+  passthru.tests.version = testers.testVersion {
+    package = adrgen;
+    command = "adrgen version";
+    version = "v${version}";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/asiermarques/adrgen";
+    description = "A command-line tool for generating and managing Architecture Decision Records";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = [maintainers.ivar];
+  };
+}

--- a/cells/std/packages/mdbook-kroki-preprocessor.nix
+++ b/cells/std/packages/mdbook-kroki-preprocessor.nix
@@ -7,7 +7,7 @@ with inputs.nixpkgs;
     pname = "mdbook-kroki-preprocessor";
     version = "0.1.0";
     nativeBuildInputs = [pkg-config];
-    buildInputs = [openssl];
+    buildInputs = [openssl] ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
 
     cargoLock = {
       lockFile = inputs.mdbook-kroki-preprocessor + "/Cargo.lock";


### PR DESCRIPTION
- downstream `adrgen` package from nixpkgs, bump to latest master with https://github.com/asiermarques/adrgen/pull/14 that fixes build on Darwin with Go 1.18
- pass `Security` framework as build input for `mdbook-kroki-preprocessor`
- verify `default` devshell on CI