### PR TITLE
properly deprecate the organelle type

### DIFF
--- a/src/validators.nix
+++ b/src/validators.nix
@@ -66,19 +66,29 @@ in {
         Please create at least one of the previous files and don't forget to add them to version control.
       ''
     else cell;
-  CellBlocks = with yants "std" "grow" "attrs";
-    list (
-      struct "cellBlock" {
-        name = string;
-        type = string;
-        actions = option (functionWithArgs {
-          system = false;
-          flake = false;
-          fragment = false;
-          fragmentRelPath = false;
-        });
-      }
-    );
+  CellBlocks = with yants "std" "grow" "attrs"; let
+    cellBlock = struct "cellBlock" {
+      name = string;
+      type = string;
+      actions = option (functionWithArgs {
+        system = false;
+        flake = false;
+        fragment = false;
+        fragmentRelPath = false;
+      });
+    };
+    organelle = l.warn "`clade` nomenclature is deprecated, rename to `type`" (struct "organelle" {
+      name = string;
+      clade = string;
+      actions = option (functionWithArgs {
+        system = false;
+        flake = false;
+        fragment = false;
+        fragmentRelPath = false;
+      });
+    });
+  in
+    list (either cellBlock organelle);
   FileSignature = file: let
     file' = prefixWithCellsFrom file;
   in


### PR DESCRIPTION
Previously, if a user still had any references to an old revision of standard in their lock file, the types defined using that standard would fail to evaluate due to the recent rename. 

This allows the old type to properly evaluate with yants while informing the user that downstream may need to update their flake.

Originally outlined in this comment: https://github.com/divnix/std/issues/116#issuecomment-1242295250