### PR TITLE
add a facility to accumulate checks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,8 +32,11 @@
     blockTypes = import ./src/blocktypes.nix {inherit (inputs) nixpkgs;};
     incl = import ./src/incl.nix {inherit (inputs) nixpkgs;};
     deSystemize = import ./src/de-systemize.nix;
-    grow = import ./src/grow.nix {inherit (inputs) nixpkgs yants;};
-    growOn = import ./src/grow-on.nix {inherit (inputs) nixpkgs yants;};
+    grow = import ./src/grow.nix {inherit (inputs) nixpkgs yants flake-utils;};
+    growOn = import ./src/grow-on.nix {
+      inherit (inputs) nixpkgs yants;
+      inherit grow;
+    };
     harvest = import ./src/harvest.nix {inherit (inputs) nixpkgs;};
     l = inputs.nixpkgs.lib // builtins;
   in

--- a/src/grow-on.nix
+++ b/src/grow-on.nix
@@ -1,9 +1,9 @@
 {
   nixpkgs,
   yants,
+  grow,
 }: let
   l = nixpkgs.lib // builtins;
-  grow = import ./grow.nix {inherit nixpkgs yants;};
   /*
     A variant of `std.grow` that let's you pass an arbitraty
     (variadic) amount of arguments after "growing" the flake.


### PR DESCRIPTION
By default, `__std.checks` will be empty, but if the user wishes to add their organelle to the checks, `recurseForDerivations = true` in their organelle.

If a user wants to opt out a specific package, they can mark it with `noStdCheck` in the derivation.

nixos/nix#4265