### PR TITLE
harvest: derive harvest from more general function 

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ That folder implements:
 - [`std.grow`][grow]: the "smart" importer
 - [`std.growOn`][grow-on]: `std.grow`-variant that recursively merges all additional variadic arguments
 - [`std.harvest`][harvest]: harvest your **Targets** into a different shape for compatibility
+- [`std.winnow`][winnow]: when more advanced harvesting is required, use this to harvest _and_ filter the output
 - [`std.incl`][incl]: a straight-forward source filter with additive semantics
 - [`std.deSystemize`][de-systemize]: a helper to hide `system` from plain sight
 - [`std.<blockType>`][blocktypes]: builtin **(Cell) Block Types** that implement **(Cell Block Type) Actions**
@@ -158,6 +159,7 @@ direnv allow
 [grow]: https://github.com/divnix/std/blob/main/src/grow.nix
 [grow-on]: https://github.com/divnix/std/blob/main/src/grow-on.nix
 [harvest]: https://github.com/divnix/std/blob/main/src/harvest.nix
+[winnow]: https://github.com/divnix/std/blob/main/src/winnow.nix
 [incl]: https://github.com/divnix/std/blob/main/src/incl.nix
 [de-systemize]: https://github.com/divnix/std/blob/main/src/de-systemize.nix
 [blocktypes]: https://github.com/divnix/std/blob/main/src/blocktypes.nix

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,8 @@
     deSystemize = import ./src/de-systemize.nix;
     grow = import ./src/grow.nix {inherit (inputs) nixpkgs yants;};
     growOn = import ./src/grow-on.nix {inherit (inputs) nixpkgs yants;};
-    harvest = import ./src/harvest.nix {inherit (inputs) nixpkgs;};
+    harvest = import ./src/harvest.nix {inherit winnow;};
+    winnow = import ./src/winnow.nix {inherit (inputs) nixpkgs;};
     l = inputs.nixpkgs.lib // builtins;
   in
     {
@@ -56,7 +57,7 @@
         ''
         blockTypes;
       inherit (blockTypes) runnables installables functions data devshells containers files microvms nixago;
-      inherit grow growOn deSystemize incl harvest;
+      inherit grow growOn deSystemize incl harvest winnow;
       systems = l.systems.doubles;
     }
     # on our own account ...

--- a/src/harvest.nix
+++ b/src/harvest.nix
@@ -1,38 +1,22 @@
-{nixpkgs}: let
-  l = nixpkgs.lib // builtins;
-  /*
-  A function that "up-lifts" your `std` targets.
+{winnow}:
+/*
+A function that "up-lifts" your `std` targets.
 
-  The transformation is: system.cell.block.target -> system.target
+The transformation is: system.cell.block.target -> system.target
 
-  You can typically use this function in a compatibility layer of soil.
+Semantically equivalent to winnow without a filter
 
-  Example:
+You can typically use this function in a compatibility layer of soil.
 
-  ```nix
-  # Soil ...
-  # nix-cli compat
-  {
-    devShell = inputs.std.harvest inputs.self ["tullia" "devshell" "default"];
-    defaultPackage = inputs.std.harvest inputs.self ["tullia" "apps" "tullia"];
-  }
-  ```
-  */
-  harvest = t: p: let
-    multiplePaths = l.isList (l.elemAt p 0);
-    hoist = path:
-      l.mapAttrs (_: v: l.getAttrFromPath path v)
-      (
-        l.filterAttrs (
-          n: v:
-            (l.elem n l.systems.doubles.all) # avoids infinit recursion
-            && (l.hasAttrByPath path v)
-        )
-        t
-      );
-  in
-    if multiplePaths
-    then l.foldl' l.recursiveUpdate {} (map (path: hoist path) p)
-    else hoist p;
-in
-  harvest
+Example:
+
+```nix
+# Soil ...
+# nix-cli compat
+{
+  devShell = inputs.std.harvest inputs.self ["tullia" "devshell" "default"];
+  defaultPackage = inputs.std.harvest inputs.self ["tullia" "apps" "tullia"];
+}
+```
+*/
+winnow true

--- a/src/winnow.nix
+++ b/src/winnow.nix
@@ -1,0 +1,48 @@
+{nixpkgs}: let
+  l = nixpkgs.lib // builtins;
+  /*
+  A function that "up-lifts" your `std` targets.
+
+  The transformation is: system.cell.block.target -> system.target
+
+  The results are filtered based on the `pred` function
+
+  You can typically use this function in a compatibility layer of soil.
+
+  Example:
+
+  ```nix
+  # Soil ...
+  # nix-cli compat
+  {
+    devShell = inputs.std.winnow (_: v: v != null) inputs.self ["tullia" "devshell" "default"];
+    defaultPackage = inputs.std.winnow (n: _: n != "cli") inputs.self ["tullia" "apps" "tullia"];
+  }
+  ```
+  */
+  winnow = pred: t: p: let
+    multiplePaths = l.isList (l.elemAt p 0);
+    hoist = path:
+      l.mapAttrs (
+        _: v: let
+          attr = l.getAttrFromPath path v;
+        in
+          # skip overhead if filtering is not needed
+          if pred
+          then attr
+          else l.filterAttrs pred attr
+      )
+      (
+        l.filterAttrs (
+          n: v:
+            (l.elem n l.systems.doubles.all) # avoids infinit recursion
+            && (l.hasAttrByPath path v)
+        )
+        t
+      );
+  in
+    if multiplePaths
+    then l.foldl' l.recursiveUpdate {} (map (path: hoist path) p)
+    else hoist p;
+in
+  winnow


### PR DESCRIPTION
After starting #126, I realized all that was needed was to modify harvest to allow for skipping marked derivations based on a predicate. Winnow is the same function as harvest, except it accepts a filter as it's first argo.