### PR TITLE
feat: allows additional options to be passed to mkOCI/mkDebugOCI

### DIFF
--- a/cells/std/lib/writeShellEntrypoint.nix
+++ b/cells/std/lib/writeShellEntrypoint.nix
@@ -204,8 +204,8 @@
   in
     inner
     // {
-      mkOCI = name: n2c.buildImage (mkOCI inner name);
-      mkDebugOCI = name: n2c.buildImage (mkDebugOCI inner name);
+      mkOCI = { name, options ? {}}: l.recursiveUpdate (n2c.buildImage (mkOCI inner name)) options;
+      mkDebugOCI = { name, options ? {}}: l.recursiveUpdate (n2c.buildImage (mkDebugOCI inner name)) options;
       inherit
         (inner)
         package

--- a/cells/std/lib/writeShellEntrypoint.nix
+++ b/cells/std/lib/writeShellEntrypoint.nix
@@ -204,8 +204,8 @@
   in
     inner
     // {
-      mkOCI = { name, options ? {}}: l.recursiveUpdate (n2c.buildImage (mkOCI inner name)) options;
-      mkDebugOCI = { name, options ? {}}: l.recursiveUpdate (n2c.buildImage (mkDebugOCI inner name)) options;
+      mkOCI = { name, options ? {}}: n2c.buildImage (l.recursiveUpdate (mkOCI inner name) options);
+      mkDebugOCI = { name, options ? {}}: n2c.buildImage (l.recursiveUpdate (mkDebugOCI inner name) options);
       inherit
         (inner)
         package


### PR DESCRIPTION
I'm not sure how to make this backward compatible. The problem is that the current structure blocks access to arguments being passed to `n2c.buildImage`. The most flexible option seems to convert the `mkOCI` functions to accept an attribute set that takes an optional `options` argument for merging against whatever the internal `mkOCI` function does. 

With this change, I can do this now:

```nix
{
  default = entrypoint.mkOCI {
    name = "docker.io/cocogitto-pr";
    options = {
      tag = "latest";
      config.Labels = {
        "org.opencontainers.image.title" = "cocogitto-pr";
        "org.opencontainers.image.version" = "0.1.0";
        "org.opencontainers.image.url" = "https://github.com/jmgilman/cocogitto-pr";
        "org.opencontainers.image.source" = "https://github.com/jmgilman/cocogitto-pr";
        "org.opencontainers.image.description" = ''
          Github Action for generating preview PRs with cocogitto
        '';
      };
    };
  };
}
```