### PR TITLE
feat: adds mkOperable and updated version of mkOCI w/ deps

### DIFF
--- a/cells/std/lib/default.nix
+++ b/cells/std/lib/default.nix
@@ -80,14 +80,16 @@ in {
     __functor configuration' {};
 
   fromMakesWith = inputs': let
-    inputsChecked = assert l.assertMsg (builtins.hasAttr "makes" inputs') (
+    inputsChecked = assert l.assertMsg (builtins.hasAttr "makes" inputs')
+    (
       l.traceSeqN 1 inputs' ''
 
         In order to be able to use 'std.std.lib.fromMakesWith', an input
         named 'makes' must be defined in the flake. See inputs above.
       ''
     );
-    assert l.assertMsg (builtins.hasAttr "nixpkgs" inputs') (
+    assert l.assertMsg (builtins.hasAttr "nixpkgs" inputs')
+    (
       l.traceSeqN 1 inputs' ''
 
         In order to be able to use 'std.std.lib.fromMakesWith', an input
@@ -95,7 +97,8 @@ in {
       ''
     ); inputs';
     makes = l.fix (
-      l.extends (
+      l.extends
+      (
         _: _: {
           inherit (inputsChecked.nixpkgs) system;
           inputs = inputsChecked;
@@ -114,7 +117,8 @@ in {
   fromMicrovmWith = import ./fromMicrovmWith.nix {inherit nixpkgs;};
 
   writeShellEntrypoint = inputs': let
-    inputsChecked = assert nixpkgs.lib.assertMsg (builtins.hasAttr "n2c" inputs') (
+    inputsChecked = assert nixpkgs.lib.assertMsg (builtins.hasAttr "n2c" inputs')
+    (
       nixpkgs.lib.traceSeqN 1 inputs' ''
 
         In order to be able to use 'std.std.lib.writeShellEntrypoint', an input
@@ -124,6 +128,26 @@ in {
     ); inputs';
   in
     import ./writeShellEntrypoint.nix {
+      inputs = inputsChecked;
+      inherit cell;
+    };
+
+  mkOperable = import ./mkOperable.nix {inherit inputs cell;};
+  mkSetup = import ./mkSetup.nix {inherit inputs cell;};
+  mkUser = import ./mkUser.nix {inherit inputs cell;};
+
+  mkOCI = inputs': let
+    inputsChecked = assert nixpkgs.lib.assertMsg (builtins.hasAttr "n2c" inputs')
+    (
+      nixpkgs.lib.traceSeqN 1 inputs' ''
+
+        In order to be able to use 'std.std.lib.mkOCI', an input
+        named 'n2c' (representing 'nlewo/nix2container') must be defined in the flake.
+        See inputs above.
+      ''
+    ); inputs';
+  in
+    import ./mkOCI.nix {
       inputs = inputsChecked;
       inherit cell;
     };

--- a/cells/std/lib/mkOCI.nix
+++ b/cells/std/lib/mkOCI.nix
@@ -1,0 +1,117 @@
+{
+  inputs,
+  cell,
+}: let
+  inherit (inputs) nixpkgs std;
+  l = nixpkgs.lib // builtins;
+  n2c = inputs.n2c.packages.nix2container;
+in
+  /*
+  Creates an OCI container image using the given operable.
+
+  Args:
+    name: The name of the image.
+    tag: Optional tag of the image (defaults to output hash)
+    setup: A list of setup tasks to run to configure the container.
+    uid: The user ID to run the container as.
+    gid: The group ID to run the container as.
+    perms: A list of permissions to set for the container.
+    labels: An attribute set of labels to set for the container. The keys are
+      automatically prefixed with "org.opencontainers.image".
+    debug: Whether to include debug tools in the container (bash, coreutils).
+    debugInputs: Additional packages to include in the container if debug is
+      enabled.
+    options: Additional options to pass to nix2container.
+
+  Returns:
+    An OCI container image (created with nix2container).
+  */
+  {
+    name,
+    operable,
+    tag ? "",
+    setup ? [],
+    uid ? "65534",
+    gid ? "65534",
+    perms ? [],
+    labels ? {},
+    debug ? false,
+    debugInputs ? [],
+    options ? {},
+  }: let
+    # Links liveness and readiness probes (if present) to /bin/* for
+    # convenience
+    livenessLink = l.optionalString (operable.passthru.livenessProbe != null) "ln -s ${l.getExe operable.passthru.livenessProbe} $out/bin/live";
+    readinessLink = l.optionalString (operable.passthru.readinessProbe != null) "ln -s ${l.getExe operable.passthru.readinessProbe} $out/bin/ready";
+
+    # Links the entrypoint to /entrypoint for convenience
+    setupLinks = cell.lib.mkSetup "links" {} ''
+      mkdir -p $out/bin
+      ln -s ${l.getExe operable} $out/bin/entrypoint
+      ${livenessLink}
+      ${readinessLink}
+    '';
+
+    # The root layer contains all of the setup tasks and any additional debug
+    # inputs if enabled
+    rootLayer =
+      [setupLinks]
+      ++ setup
+      ++ l.optionals debug [
+        (nixpkgs.buildEnv {
+          name = "root";
+          paths = [nixpkgs.bashInteractive nixpkgs.coreutils] ++ debugInputs;
+          pathsToLink = ["/bin"];
+        })
+      ];
+    # This is what get passed to nix2container.buildImage
+    config =
+      {
+        inherit name;
+
+        # Setup tasks can include permissions via the passthru.perms attribute
+        perms = (l.map (s: l.optionalAttrs (s ? passthru && s.passthru ? perms) s.passthru.perms) setup) ++ perms;
+
+        # Layers are nested to reduce duplicate paths in the image
+        layers = [
+          # Primary layer is the package layer
+          (n2c.buildLayer {
+            copyToRoot = [operable.passthru.package];
+            maxLayers = 40;
+            layers = [
+              # Entrypoint layer
+              (n2c.buildLayer {
+                deps = [operable];
+                maxLayers = 10;
+              })
+              # Runtime inputs layer
+              (n2c.buildLayer {
+                deps = operable.passthru.runtimeInputs;
+                maxLayers = 10;
+              })
+            ];
+          })
+          # Liveness and readiness probe layer
+          (n2c.buildLayer {
+            deps =
+              []
+              ++ (l.optionals (operable.passthru ? livenessProbe) [(n2c.buildLayer {deps = [operable.passthru.livenessProbe];})])
+              ++ (l.optionals (operable.passthru ? readinessProbe) [(n2c.buildLayer {deps = [operable.passthru.readinessProbe];})]);
+            maxLayers = 10;
+          })
+        ];
+
+        # Max layers is 127, we only go up to 120
+        maxLayers = 50;
+        copyToRoot = rootLayer;
+
+        config = {
+          User = uid;
+          Group = gid;
+          Entrypoint = ["/bin/entrypoint"];
+          Labels = l.mapAttrs' (n: v: l.nameValuePair "org.opencontainers.image.${n}" v) labels;
+        };
+      }
+      // l.optionalAttrs (tag != "") {inherit tag;};
+  in
+    n2c.buildImage (l.recursiveUpdate config options)

--- a/cells/std/lib/mkOperable.nix
+++ b/cells/std/lib/mkOperable.nix
@@ -1,0 +1,54 @@
+{
+  inputs,
+  cell,
+}: let
+  inherit (inputs) nixpkgs std;
+  l = nixpkgs.lib // builtins;
+in
+  /*
+  Makes a package operable by configuring the necessary runtime environment.
+
+  Args:
+    package: The package to wrap.
+    runtimeScript: A bash script to run at runtime.
+    runtimeEnv: An attribute set of environment variables to set at runtime.
+    runtimeInputs: A list of packages to add to the runtime environment.
+    livenessProbe: An optional derivation to run to check if the program is alive.
+    readinessProbe: An optional derivation to run to check if the program is ready.
+
+  Returns:
+    An operable for the given package.
+  */
+  {
+    package,
+    runtimeScript,
+    runtimeEnv ? {},
+    runtimeInputs ? [],
+    livenessProbe ? null,
+    readinessProbe ? null,
+  }: let
+    # Exports environment variables to the runtime environment before running
+    # the runtime script
+    text = ''
+      ${l.concatStringsSep "\n" (l.mapAttrsToList (n: v: "export ${n}=${''"$''}{${n}:-${toString v}}${''"''}") runtimeEnv)}
+      ${runtimeScript}
+    '';
+  in
+    (nixpkgs.writeShellApplication
+      {
+        inherit text runtimeInputs;
+        name = "operable-${package.name}";
+      })
+    // {
+      # The livenessProbe and readinessProbe are picked up in later stages
+      passthru =
+        {
+          inherit package runtimeInputs;
+        }
+        // l.optionalAttrs (livenessProbe != null) {
+          inherit livenessProbe;
+        }
+        // l.optionalAttrs (readinessProbe != null) {
+          inherit readinessProbe;
+        };
+    }

--- a/cells/std/lib/mkSetup.nix
+++ b/cells/std/lib/mkSetup.nix
@@ -1,0 +1,26 @@
+{
+  inputs,
+  cell,
+}: let
+  inherit (inputs) nixpkgs std;
+  l = nixpkgs.lib // builtins;
+in
+  /*
+  Creates a new setup task for configuring a container.
+
+  Args:
+    name: A name for the task.
+    perms: An attribute set of permissions to set for this task.
+    contents: The contents of the setup task. This is a bash script.
+
+  Returns:
+    A setup task.
+  */
+  name: perms: contents: let
+    setup = nixpkgs.runCommand "oci-setup-${name}" {} contents;
+  in
+    setup
+    // l.optionalAttrs (perms != {})
+    (
+      l.recursiveUpdate {passthru.perms = perms;} {passthru.perms.path = setup;}
+    )

--- a/cells/std/lib/mkUser.nix
+++ b/cells/std/lib/mkUser.nix
@@ -1,0 +1,56 @@
+{
+  inputs,
+  cell,
+}: let
+  inherit (inputs) nixpkgs std;
+  l = nixpkgs.lib // builtins;
+in
+  /*
+  Creates a setup task which adds the given user to the container.
+
+  Args:
+    user: Username
+    uid: User ID
+    group: Group name
+    gid: Group ID
+    withHome: If true, creates a home directory for the user.
+
+  Returns:
+    A setup task which adds the user to the container.
+  */
+  {
+    user,
+    uid,
+    group,
+    gid,
+    withHome ? false,
+  }: let
+    perms = l.optionalAttrs withHome {
+      regex = "/home/${user}";
+      mode = "0744";
+      uid = l.toInt uid;
+      gid = l.toInt gid;
+      uname = user;
+      gname = group;
+    };
+  in
+    # https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/docker/default.nix#L177-L199
+    cell.lib.mkSetup "users" perms (''
+        mkdir -p $out/etc/pam.d
+
+        echo "${user}:x:${uid}:${gid}::" > $out/etc/passwd
+        echo "${user}:!x:::::::" > $out/etc/shadow
+
+        echo "${group}:x:${gid}:" > $out/etc/group
+        echo "${group}:x::" > $out/etc/gshadow
+
+        cat > $out/etc/pam.d/other <<EOF
+        account sufficient pam_unix.so
+        auth sufficient pam_rootok.so
+        password requisite pam_unix.so nullok sha512
+        session required pam_unix.so
+        EOF
+
+        touch $out/etc/login.defs
+      ''
+      + l.optionalString withHome "\nmkdir -p $out/home/${user}")


### PR DESCRIPTION
This PR introduces a few things.

## Entrypoint -> Operable

See: [The four layers](https://divnix.github.io/std/patterns/four-packaging-layers.html#the-layers)

Previously, a package would be turned into an _entrypoint_. This was necessary to transform a package, which may or may not be "operable", into a self-contained derivation that included everything required to operate the package (runtime inputs, environment variables, etc.). The problem is that _entrypoint_ is universally associated with containers, and thus the _entrypoint layer_ risks unnecessarily bleeding into a downstream layer.

This PR begins to change _entrypoint_ to _operable_ to distinguish the transformation better.

## mkOperable

Concretely implements the above change. Returns an "operable" derivation for a given package. It also includes optional liveness and readiness probes which can pass thru to later layers. 

## mkOCI and deps

A more robust version of the current `mkOCI` implementation. Transforms an operable into an OCI image. It brings the following additional benefits:

- Offers more tuning options to better control the final image (i.e. tag, labels, etc.).
- Adds support for _setup tasks_ (via `mkSetup`) that allows arbitrarily modifying the root filesystem of the container.
- Allows controlling the running user, including adding a new user to the image with the `mkUser` setup task.
- Additional layer optimizations to reduce overall image size.
- Adds a catch-all `options` argument for augmenting the final arguments sent to `n2c.buildImage`

Note that this PR is dependent on [this PR](https://github.com/nlewo/nix2container/pull/47) which adds support for modifying file ownership. It should not be merged before that one. 

