### PR TITLE
feat: adds mkDevOCI for generating devcontainers

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "std-dev",
+    "image": "std-vscode",
     "settings": {
         "terminal.integrated.shell.linux": "/bin/bash"
     }

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "image": "std-dev",
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+    }
+}

--- a/cells/_automation/containers.nix
+++ b/cells/_automation/containers.nix
@@ -8,7 +8,7 @@ in {
   dev = lib.ops.mkDevOCI {
     name = "docker.io/std-dev";
     tag = "latest";
-    devshell = inputs.cells._automation.devshells.default;
+    devshell = cell.devshells.default;
     labels = {
       title = "std-dev";
       version = "0.1.0";
@@ -22,7 +22,7 @@ in {
   vscode = lib.ops.mkDevOCI {
     name = "docker.io/std-vscode";
     tag = "latest";
-    devshell = inputs.cells._automation.devshells.default;
+    devshell = cell.devshells.default;
     vscode = true;
     labels = {
       title = "std-dev";

--- a/cells/_automation/containers.nix
+++ b/cells/_automation/containers.nix
@@ -1,11 +1,10 @@
-{ inputs
-, cell
-}:
-let
+{
+  inputs,
+  cell,
+}: let
   inherit (inputs.cells) nixpkgs lib;
   l = nixpkgs.lib // builtins;
-in
-{
+in {
   dev = lib.ops.mkDevOCI {
     name = "docker.io/std-dev";
     tag = "latest";

--- a/cells/_automation/containers.nix
+++ b/cells/_automation/containers.nix
@@ -1,0 +1,23 @@
+{ inputs
+, cell
+}:
+let
+  inherit (inputs.cells) nixpkgs lib;
+  l = nixpkgs.lib // builtins;
+in
+{
+  dev = lib.ops.mkDevOCI {
+    name = "docker.io/std-dev";
+    tag = "latest";
+    devshell = inputs.cells._automation.devshells.default;
+    labels = {
+      title = "std-dev";
+      version = "0.1.0";
+      url = "https://github.com/divnix";
+      source = "https://github.com/divnix";
+      description = ''
+        A prepackaged devcontainer for hacking on std
+      '';
+    };
+  };
+}

--- a/cells/_automation/containers.nix
+++ b/cells/_automation/containers.nix
@@ -16,7 +16,22 @@ in
       url = "https://github.com/divnix";
       source = "https://github.com/divnix";
       description = ''
-        A prepackaged devcontainer for hacking on std
+        A prepackaged container for hacking on std
+      '';
+    };
+  };
+  vscode = lib.ops.mkDevOCI {
+    name = "docker.io/std-vscode";
+    tag = "latest";
+    devshell = inputs.cells._automation.devshells.default;
+    vscode = true;
+    labels = {
+      title = "std-dev";
+      version = "0.1.0";
+      url = "https://github.com/divnix";
+      source = "https://github.com/divnix";
+      description = ''
+        A prepackaged vscode devcontainer for hacking on std
       '';
     };
   };

--- a/cells/lib/ops.nix
+++ b/cells/lib/ops.nix
@@ -23,6 +23,11 @@ in {
     inputs = requireInput "n2c" "github:nlewo/nix2container" "std.lib.ops.mkOCI";
   };
 
+  mkDevOCI = import ./ops/mkDevOCI.nix {
+    inherit cell;
+    inputs = requireInput "n2c" "github:nlewo/nix2container" "std.lib.ops.mkDevOCI";
+  };
+
   mkStandardOCI = import ./ops/mkStandardOCI.nix {
     inherit cell;
     inputs = requireInput "n2c" "github:nlewo/nix2container" "std.lib.ops.mkStandardOCI";

--- a/cells/lib/ops.nix
+++ b/cells/lib/ops.nix
@@ -18,18 +18,7 @@ in {
   mkUser = import ./ops/mkUser.nix {inherit inputs cell;};
   writeScript = import ./ops/writeScript.nix {inherit inputs cell;};
 
-  mkOCI = import ./ops/mkOCI.nix {
-    inherit cell;
-    inputs = requireInput "n2c" "github:nlewo/nix2container" "std.lib.ops.mkOCI";
-  };
-
-  mkDevOCI = import ./ops/mkDevOCI.nix {
-    inherit cell;
-    inputs = requireInput "n2c" "github:nlewo/nix2container" "std.lib.ops.mkDevOCI";
-  };
-
-  mkStandardOCI = import ./ops/mkStandardOCI.nix {
-    inherit cell;
-    inputs = requireInput "n2c" "github:nlewo/nix2container" "std.lib.ops.mkStandardOCI";
-  };
+  mkOCI = import ./ops/mkOCI.nix {inherit inputs cell;};
+  mkDevOCI = import ./ops/mkDevOCI.nix {inherit inputs cell;};
+  mkStandardOCI = import ./ops/mkStandardOCI.nix {inherit inputs cell;};
 }

--- a/cells/lib/ops/mkDevOCI.nix
+++ b/cells/lib/ops/mkDevOCI.nix
@@ -22,14 +22,12 @@ in
     shellName = builtins.unsafeDiscardStringContext (l.baseNameOf (l.getExe runtimeShell));
     shellConfigs = {
       bash = ''
-        mkdir -p $out/home/${user}
-        cat >$out/home/${user}/.bashrc << EOF
+        cat >$out/etc/bashrc << EOF
         eval "\$(direnv hook bash)"
         EOF
       '';
       zsh = ''
-        mkdir -p $out/home/${user}
-        cat >$out/home/${user}/.zshrc << EOF
+        cat >$out/etc/zshrc << EOF
         eval "\$(direnv hook zsh)"
         EOF
       '';
@@ -59,12 +57,6 @@ in
         {
           regex = "/tmp";
           mode = "0777";
-        }
-        {
-          regex = "/home/${user}";
-          mode = "0744";
-          uid = 1000;
-          gid = 1000;
         }
       ]
       ''

--- a/cells/lib/ops/mkDevOCI.nix
+++ b/cells/lib/ops/mkDevOCI.nix
@@ -31,6 +31,7 @@ in
       group = user;
       uid = "1000";
       gid = "1000";
+      shell = l.getExe runtimeShell;
       withHome = true;
       withRoot = true;
     };
@@ -118,6 +119,7 @@ in
     commonDeps = [
       nixpkgs.nano
       nixpkgs.gnupg
+      nixpkgs.openssh
     ];
 
     # The entrypoint should be long-running by default

--- a/cells/lib/ops/mkDevOCI.nix
+++ b/cells/lib/ops/mkDevOCI.nix
@@ -116,6 +116,7 @@ in
       nixpkgs.gawk
       nixpkgs.gnugrep
       nixpkgs.gnused
+      nixpkgs.diffutils
     ];
 
     # These packages are required by vscode

--- a/cells/lib/ops/mkDevOCI.nix
+++ b/cells/lib/ops/mkDevOCI.nix
@@ -120,7 +120,7 @@ let
   # These packages are required by nix and its direnv integration test
   nixDeps = [
     nixpkgs.direnv
-    nixpkgs.git
+    nixpkgs.gitMinimal
     nixpkgs.nix
     nixpkgs.gawk
     nixpkgs.gnugrep
@@ -214,8 +214,6 @@ cell.ops.mkOCI {
         "NIX_PAGER=cat"
         # This file is created when nixpkgs.cacert is copied to the root
         "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
-        # Pin <nixpkgs> to the version used to build the container
-        "NIX_PATH=nixpkgs=${nixpkgs.path}"
         # Nix expects a user to be set
         "USER=${user'}"
       ] ++ (l.optionals vscode [
@@ -223,6 +221,9 @@ cell.ops.mkOCI {
         # container is started. It is, unfortunately, dynamically linked and
         # we need to resort to some hackery to get it to run.
         "LD_LIBRARY_PATH=${nixpkgs.stdenv.cc.cc.lib}/lib"
+      ]) ++ (l.optionals (! slim) [
+        # Include <nixpkgs> to support installing additional packages
+        "NIX_PATH=nixpkgs=${nixpkgs.path}"
       ]);
       Volumes = (l.optionalAttrs vscode { "/vscode" = { }; });
     }

--- a/cells/lib/ops/mkDevOCI.nix
+++ b/cells/lib/ops/mkDevOCI.nix
@@ -47,7 +47,7 @@ in
       then "vscode"
       else user;
 
-    # Apply the correct hook based on the given runtime shell
+    # Determine proper shell configuration file based on runtime shell
     # Only bash/zsh are supported currently
     shellName = builtins.unsafeDiscardStringContext (l.baseNameOf (l.getExe runtimeShell));
     shellConfigs = {
@@ -140,7 +140,7 @@ in
         ln -s ${nixpkgs.coreutils}/bin/env $out/usr/bin/env
       '';
 
-    # These packages are required by nix and its direnv integration test
+    # These packages are required by nix and its direnv integration
     nixDeps = [
       nixpkgs.direnv
       nixpkgs.gitMinimal

--- a/cells/lib/ops/mkDevOCI.nix
+++ b/cells/lib/ops/mkDevOCI.nix
@@ -1,52 +1,51 @@
-{
-  inputs,
-  cell,
-}: let
+{ inputs
+, cell
+,
+}:
+let
   inherit (inputs) nixpkgs std;
   l = nixpkgs.lib // builtins;
   n2c = inputs.n2c.packages.nix2container;
 in
-  {
-    name,
-    devshell,
-    runtimeShell ? nixpkgs.bashInteractive,
-    user ? "vscode",
-    tag ? "",
-    setup ? [],
-    perms ? [],
-    labels ? {},
-    options ? {},
-  }: let
-    # Apply the correct hook based on the given runtime shell
-    # Only bash/zsh are supported currently
-    shellName = builtins.unsafeDiscardStringContext (l.baseNameOf (l.getExe runtimeShell));
-    shellConfigs = {
-      bash = "bashrc";
-      zsh = "zshrc";
-    };
+{ name
+, devshell
+, runtimeShell ? nixpkgs.bashInteractive
+, user ? "user"
+, vscode ? false
+, tag ? ""
+, setup ? [ ]
+, perms ? [ ]
+, labels ? { }
+, options ? { }
+,
+}:
+let
+  # vscode defaults to "vscode" as the user
+  user' = if vscode then "vscode" else user;
 
-    # Configure local user
-    setupUser = cell.ops.mkUser {
-      inherit user;
-      group = user;
-      uid = "1000";
-      gid = "1000";
-      shell = l.getExe runtimeShell;
-      withHome = true;
-      withRoot = true;
-    };
+  # Apply the correct hook based on the given runtime shell
+  # Only bash/zsh are supported currently
+  shellName = builtins.unsafeDiscardStringContext (l.baseNameOf (l.getExe runtimeShell));
+  shellConfigs = {
+    bash = "bashrc";
+    zsh = "zshrc";
+  };
 
-    # Configure direnv, git, and nix. Additionally, perform some setup for
-    # vscode which makes some basic assumptions about the environment.
-    setupEnv =
-      cell.ops.mkSetup "container"
+  # Configure local user
+  setupUser = cell.ops.mkUser {
+    user = user';
+    group = user';
+    uid = "1000";
+    gid = "1000";
+    shell = l.getExe runtimeShell;
+    withHome = true;
+    withRoot = true;
+  };
+
+  # Configure direnv, git, and nix
+  setupEnv =
+    cell.ops.mkSetup "container"
       [
-        {
-          regex = "/vscode";
-          mode = "0744";
-          uid = 1000;
-          gid = 1000;
-        }
         {
           regex = "/tmp";
           mode = "0777";
@@ -55,9 +54,6 @@ in
       ''
         # Setup tmp folder
         mkdir -p $out/tmp
-
-        # Setup vscode directory
-        mkdir -p $out/vscode
 
         # Enable nix flakes
         mkdir -p $out/etc
@@ -85,6 +81,23 @@ in
           [safe]
               directory = *
         EOF
+      '';
+
+  # Setup the environment in such a way to make it compatible with what a
+  # vscode devcontainer expects
+  setupVSCode =
+    cell.ops.mkSetup "vscode"
+      [
+        {
+          regex = "/vscode";
+          mode = "0744";
+          uid = 1000;
+          gid = 1000;
+        }
+      ]
+      ''
+        # Setup vscode directory
+        mkdir -p $out/vscode
 
         # vscode uses /bin/sh for running commands
         mkdir -p $out/bin
@@ -98,117 +111,113 @@ in
         ln -s ${nixpkgs.coreutils}/bin/env $out/usr/bin/env
       '';
 
-    # These packages are required by nix and its direnv integration test
-    nixDeps = [
-      nixpkgs.direnv
-      nixpkgs.git
-      nixpkgs.nix
-      nixpkgs.gawk
-      nixpkgs.gnugrep
-      nixpkgs.gnused
-      nixpkgs.diffutils
-    ];
+  # These packages are required by nix and its direnv integration test
+  nixDeps = [
+    nixpkgs.direnv
+    nixpkgs.git
+    nixpkgs.nix
+    nixpkgs.gawk
+    nixpkgs.gnugrep
+    nixpkgs.gnused
+    nixpkgs.diffutils
+  ];
 
-    # These packages are required by vscode
-    vscodeDeps = [
-      nixpkgs.gnutar
-      nixpkgs.gzip
-    ];
+  # These are common packages that are useful for development
+  commonDeps = [
+    nixpkgs.nano
+    nixpkgs.gnupg
+    nixpkgs.openssh
+  ];
 
-    # These are common packages that are useful for development
-    commonDeps = [
-      nixpkgs.nano
-      nixpkgs.gnupg
-      nixpkgs.openssh
-    ];
+  # These packages are required by vscode
+  vscodeDeps = [
+    nixpkgs.gnutar
+    nixpkgs.gzip
+  ];
 
-    # The entrypoint should be long-running by default
-    entrypoint = cell.ops.writeScript {
-      name = "entrypoint";
-      text = ''
-        #!${l.getExe runtimeShell}
+  # The entrypoint should be long-running by default
+  entrypoint = cell.ops.writeScript {
+    name = "entrypoint";
+    text = ''
+      #!${l.getExe runtimeShell}
 
-        if [ $# -eq 0 ]; then
-            while :; do sleep 2073600; done
-        else
-            "$@" &
-        fi
+      if [ $# -eq 0 ]; then
+          while :; do sleep 2073600; done
+      else
+          "$@" &
+      fi
 
-        wait -n
-      '';
-    };
-  in
-    cell.ops.mkOCI {
-      inherit entrypoint name tag labels perms;
+      wait -n
+    '';
+  };
+in
+cell.ops.mkOCI {
+  inherit entrypoint name tag labels perms;
 
-      # No particular reason for using 1000 here other than it's idiomatic
-      uid = "1000";
-      gid = "1000";
+  # No particular reason for using 1000 here other than it's idiomatic
+  uid = "1000";
+  gid = "1000";
 
-      setup =
-        [
-          setupEnv
-          setupUser
-        ]
-        ++ setup;
+  setup = [ setupEnv setupUser ]
+    ++ setup
+    ++ (l.optionals vscode [ setupVSCode ]);
 
-      layers = [
-        (n2c.buildLayer {
-          copyToRoot = [
-            (nixpkgs.buildEnv
-              {
-                name = "devshell";
-                paths =
-                  [
-                    nixpkgs.coreutils
-                    devshell
-                    runtimeShell
-                  ]
-                  ++ commonDeps
-                  ++ nixDeps
-                  ++ vscodeDeps;
+  layers = [
+    (n2c.buildLayer {
+      copyToRoot = [
+        (nixpkgs.buildEnv
+          {
+            name = "devshell";
+            paths =
+              [
+                nixpkgs.coreutils
+                devshell
+                runtimeShell
+              ]
+              ++ commonDeps
+              ++ nixDeps
+              ++ (l.optionals vscode vscodeDeps);
 
-                pathsToLink = ["/bin"];
-              })
-            # Required for fetching additional packages
-            nixpkgs.cacert
-          ];
-          maxLayers = 100;
-        })
+            pathsToLink = [ "/bin" ];
+          })
+        # Required for fetching additional packages
+        nixpkgs.cacert
       ];
+      maxLayers = 100;
+    })
+  ];
 
-      options = l.recursiveUpdate options {
-        # Initialize the nix database so we can use the nix CLI
-        initializeNixDatabase = true;
+  options = l.recursiveUpdate options {
+    # Initialize the nix database so we can use the nix CLI
+    initializeNixDatabase = true;
 
-        # This configures a single-user environment where the container user
-        # owns all of /nix
-        nixUid = 1000;
-        nixGid = 1000;
+    # This configures a single-user environment where the container user
+    # owns all of /nix
+    nixUid = 1000;
+    nixGid = 1000;
 
-        config = {
-          Env = [
-            # Tell direnv to find it's config in /etc
-            "DIRENV_CONFIG=/etc"
-            # Required by many tools
-            "HOME=/home/${user}"
-            # Nix related environment variables
-            "NIX_CONF_DIR=/etc"
-            "NIX_PAGER=cat"
-            # This file is created when nixpkgs.cacert is copied to the root
-            "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
-            # Pin <nixpkgs> to the version used to build the container
-            "NIX_PATH=nixpkgs=${nixpkgs.path}"
-            # Nix expects a user to be set
-            "USER=${user}"
-            # vscode ships with its own nodejs binary that it uploads when the
-            # container is started. It is, unfortunately, dynamically linked and
-            # we need to resort to some hackery to get it to run.
-            "LD_LIBRARY_PATH=${nixpkgs.stdenv.cc.cc.lib}/lib"
-          ];
-          Volumes = {
-            "/vscode" = {};
-          };
-        };
-      };
-    }
+    config = {
+      Env = [
+        # Tell direnv to find it's config in /etc
+        "DIRENV_CONFIG=/etc"
+        # Required by many tools
+        "HOME=/home/${user'}"
+        # Nix related environment variables
+        "NIX_CONF_DIR=/etc"
+        "NIX_PAGER=cat"
+        # This file is created when nixpkgs.cacert is copied to the root
+        "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+        # Pin <nixpkgs> to the version used to build the container
+        "NIX_PATH=nixpkgs=${nixpkgs.path}"
+        # Nix expects a user to be set
+        "USER=${user'}"
+      ] ++ (l.optionals vscode [
+        # vscode ships with its own nodejs binary that it uploads when the
+        # container is started. It is, unfortunately, dynamically linked and
+        # we need to resort to some hackery to get it to run.
+        "LD_LIBRARY_PATH=${nixpkgs.stdenv.cc.cc.lib}/lib"
+      ]);
+      Volumes = (l.optionalAttrs vscode { "/vscode" = { }; });
+    };
+  };
+}

--- a/cells/lib/ops/mkDevOCI.nix
+++ b/cells/lib/ops/mkDevOCI.nix
@@ -1,0 +1,219 @@
+{
+  inputs,
+  cell,
+}: let
+  inherit (inputs) nixpkgs std;
+  l = nixpkgs.lib // builtins;
+  n2c = inputs.n2c.packages.nix2container;
+in
+  {
+    name,
+    devshell,
+    runtimeShell ? nixpkgs.bashInteractive,
+    user ? "vscode",
+    tag ? "",
+    setup ? [],
+    perms ? [],
+    labels ? {},
+    options ? {},
+  }: let
+    # Apply the correct hook based on the given runtime shell
+    # Only bash/zsh are supported currently
+    shellName = builtins.unsafeDiscardStringContext (l.baseNameOf (l.getExe runtimeShell));
+    shellConfigs = {
+      bash = ''
+        mkdir -p $out/home/${user}
+        cat >$out/home/${user}/.bashrc << EOF
+        eval "\$(direnv hook bash)"
+        EOF
+      '';
+      zsh = ''
+        mkdir -p $out/home/${user}
+        cat >$out/home/${user}/.zshrc << EOF
+        eval "\$(direnv hook zsh)"
+        EOF
+      '';
+    };
+
+    # Configure local user
+    setupUser = cell.ops.mkUser {
+      inherit user;
+      group = user;
+      uid = "1000";
+      gid = "1000";
+      withHome = true;
+      withRoot = true;
+    };
+
+    # Configure direnv, git, and nix. Additionally, perform some setup for
+    # vscode which makes some basic assumptions about the environment.
+    setupEnv =
+      cell.ops.mkSetup "container"
+      [
+        {
+          regex = "/vscode";
+          mode = "0744";
+          uid = 1000;
+          gid = 1000;
+        }
+        {
+          regex = "/tmp";
+          mode = "0777";
+        }
+        {
+          regex = "/home/${user}";
+          mode = "0744";
+          uid = 1000;
+          gid = 1000;
+        }
+      ]
+      ''
+        # Setup tmp folder
+        mkdir -p $out/tmp
+
+        # Setup vscode directory
+        mkdir -p $out/vscode
+
+        # Enable nix flakes
+        mkdir -p $out/etc
+        echo "sandbox = false" > $out/etc/nix.conf
+        echo "experimental-features = nix-command flakes" >> $out/etc/nix.conf
+
+        # Increase warn timeout and whitelist all paths
+        cat >$out/etc/direnv.toml << EOF
+        [global]
+        warn_timeout = "10m"
+        [whitelist]
+        prefix = [ "/" ]
+        EOF
+
+        # Add direnv shim
+        ${shellConfigs.${shellName}}
+
+        # Disable git safe directory
+        cat >$out/etc/gitconfig <<EOF
+          [safe]
+              directory = *
+        EOF
+
+        # vscode uses /bin/sh for running commands
+        mkdir -p $out/bin
+        ln -s ${l.getExe runtimeShell} $out/bin/sh
+
+        # The bundled nodejs binary is hardcoded to look in /lib
+        ln -s ${nixpkgs.glibc}/lib $out/lib
+
+        # Some of the bundled scripts use a /usr/bin/env shebang
+        mkdir -p $out/usr/bin
+        ln -s ${nixpkgs.coreutils}/bin/env $out/usr/bin/env
+      '';
+
+    # These packages are required by nix and its direnv integration
+    nixDeps = [
+      nixpkgs.direnv
+      nixpkgs.git
+      nixpkgs.nix
+      nixpkgs.gawk
+      nixpkgs.gnugrep
+      nixpkgs.gnused
+    ];
+
+    # These packages are required by vscode
+    vscodeDeps = [
+      nixpkgs.gnutar
+      nixpkgs.gzip
+    ];
+
+    # These are common packages that are useful for development
+    commonDeps = [
+      nixpkgs.nano
+    ];
+
+    # The entrypoint should be long-running by default
+    entrypoint = cell.ops.writeScript {
+      name = "entrypoint";
+      text = ''
+        #!${l.getExe runtimeShell}
+
+        if [ $# -eq 0 ]; then
+            while :; do sleep 2073600; done
+        else
+            "$@" &
+        fi
+
+        wait -n
+      '';
+    };
+  in
+    cell.ops.mkOCI {
+      inherit entrypoint name tag labels perms;
+
+      # No particular reason for using 1000 here other than it's idiomatic
+      uid = "1000";
+      gid = "1000";
+
+      setup =
+        [
+          setupEnv
+          setupUser
+        ]
+        ++ setup;
+
+      layers = [
+        (n2c.buildLayer {
+          copyToRoot = [
+            (nixpkgs.buildEnv
+              {
+                name = "devshell";
+                paths =
+                  [
+                    nixpkgs.coreutils
+                    devshell
+                    runtimeShell
+                  ]
+                  ++ commonDeps
+                  ++ nixDeps
+                  ++ vscodeDeps;
+
+                pathsToLink = ["/bin"];
+              })
+            # Required for fetching additional packages
+            nixpkgs.cacert
+          ];
+          maxLayers = 100;
+        })
+      ];
+
+      options = l.recursiveUpdate options {
+        # Initialize the nix database so we can use the nix CLI
+        initializeNixDatabase = true;
+
+        # This configures a single-user environment where the container user
+        # owns all of /nix
+        nixUid = 1000;
+        nixGid = 1000;
+
+        config = {
+          Env = [
+            # Tell direnv to find it's config in /etc
+            "DIRENV_CONFIG=/etc"
+            # Required by many tools
+            "HOME=/home/${user}"
+            # Nix related environment variables
+            "NIX_CONF_DIR=/etc"
+            "NIX_PAGER=cat"
+            # This file is created when nixpkgs.cacert is copied to the root
+            "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+            # Nix expects a user to be set
+            "USER=${user}"
+            # vscode ships with its own nodejs binary that it uploads when the
+            # container is started. It is, unfortunately, dynamically linked and
+            # we need to resort to some hackery to get it to run.
+            "LD_LIBRARY_PATH=${nixpkgs.stdenv.cc.cc.lib}/lib"
+          ];
+          Volumes = {
+            "/vscode" = {};
+          };
+        };
+      };
+    }

--- a/cells/lib/ops/mkDevOCI.nix
+++ b/cells/lib/ops/mkDevOCI.nix
@@ -218,6 +218,7 @@ cell.ops.mkOCI {
         "LD_LIBRARY_PATH=${nixpkgs.stdenv.cc.cc.lib}/lib"
       ]);
       Volumes = (l.optionalAttrs vscode { "/vscode" = { }; });
-    };
+    }
+    // (l.optionalAttrs (! vscode) { WorkingDir = "/work"; });
   };
 }

--- a/cells/lib/ops/mkDevOCI.nix
+++ b/cells/lib/ops/mkDevOCI.nix
@@ -117,6 +117,7 @@ in
     # These are common packages that are useful for development
     commonDeps = [
       nixpkgs.nano
+      nixpkgs.gnupg
     ];
 
     # The entrypoint should be long-running by default

--- a/cells/lib/ops/mkDevOCI.nix
+++ b/cells/lib/ops/mkDevOCI.nix
@@ -12,6 +12,7 @@ in
 , runtimeShell ? nixpkgs.bashInteractive
 , user ? "user"
 , vscode ? false
+, slim ? false
 , tag ? ""
 , setup ? [ ]
 , perms ? [ ]
@@ -174,8 +175,8 @@ cell.ops.mkOCI {
                 devshell
                 runtimeShell
               ]
-              ++ commonDeps
               ++ nixDeps
+              ++ (l.optionals (! slim) commonDeps)
               ++ (l.optionals vscode vscodeDeps);
 
             pathsToLink = [ "/bin" ];

--- a/cells/lib/ops/mkDevOCI.nix
+++ b/cells/lib/ops/mkDevOCI.nix
@@ -77,6 +77,11 @@ let
         # Put local profile in path
         echo 'export PATH="$HOME/.nix-profile/bin:/nix/var/nix/profiles/default/bin:$PATH"' >> $out/etc/${shellConfigs.${shellName}}
 
+        # Optionally configure starship
+        cat >>$out/etc/${shellConfigs.${shellName}} << EOF
+        ${l.optionalString (! slim) ''eval "\$(starship init ${shellName})"''}
+        EOF
+
         # Disable git safe directory
         cat >$out/etc/gitconfig <<EOF
           [safe]
@@ -128,6 +133,7 @@ let
     nixpkgs.nano
     nixpkgs.gnupg
     nixpkgs.openssh
+    nixpkgs.starship
   ];
 
   # These packages are required by vscode

--- a/cells/lib/ops/mkDevOCI.nix
+++ b/cells/lib/ops/mkDevOCI.nix
@@ -17,6 +17,7 @@ in
   vscode: If true, makes this image compatible with vscode devcontainers
   slim: If true, omits including nixpkgs and some common development tools
   tag: Optional tag of the image (defaults to output hash)
+  pkgs: Additional pkgs to include in the image (symlinked to /bin)
   setup: A list of additional setup tasks to run to configure the container.
   perms: A list of permissions to set for the container.
   labels: An attribute set of labels to set for the container. The keys are
@@ -30,10 +31,11 @@ in
     name,
     devshell,
     runtimeShell ? nixpkgs.bashInteractive,
-    user ? "user",
     vscode ? false,
     slim ? false,
+    user ? "user",
     tag ? "",
+    pkgs ? [],
     setup ? [],
     perms ? [],
     labels ? {},
@@ -204,6 +206,7 @@ in
                     runtimeShell
                   ]
                   ++ nixDeps
+                  ++ pkgs
                   ++ (l.optionals (! slim) commonDeps)
                   ++ (l.optionals vscode vscodeDeps);
 

--- a/cells/lib/ops/mkOperable.nix
+++ b/cells/lib/ops/mkOperable.nix
@@ -45,7 +45,7 @@ in
     };
 
     # Configure debug environment
-    banner = nixpkgs.runCommandNoCC "debug-banner" {} ''
+    banner = nixpkgs.runCommand "debug-banner" {} ''
       ${nixpkgs.figlet}/bin/figlet -f banner "STD Debug" > $out
     '';
     debug = cell.ops.writeScript {

--- a/cells/lib/ops/mkSetup.nix
+++ b/cells/lib/ops/mkSetup.nix
@@ -17,7 +17,7 @@ in
     A setup task.
   */
   name: perms: contents: let
-    setup = nixpkgs.runCommandNoCC "oci-setup-${name}" {} contents;
+    setup = nixpkgs.runCommand "oci-setup-${name}" {} contents;
     perms' = l.map (p: p // { path = setup; }) perms;
   in
     setup

--- a/cells/lib/ops/mkUser.nix
+++ b/cells/lib/ops/mkUser.nix
@@ -23,6 +23,7 @@ in
     uid,
     group,
     gid,
+    shell ? "",
     withHome ? false,
     withRoot ? false,
   }: let
@@ -48,7 +49,7 @@ in
     cell.ops.mkSetup "users" perms ''
         mkdir -p $out/etc/pam.d
 
-        echo "${user}:x:${uid}:${gid}::" > $out/etc/passwd
+        echo "${user}:x:${uid}:${gid}::${l.optionalString withHome "/home/${user}"}:${shell}" > $out/etc/passwd
         echo "${user}:!x:::::::" > $out/etc/shadow
 
         echo "${group}:x:${gid}:" > $out/etc/group

--- a/cells/lib/ops/writeShellEntrypoint.nix
+++ b/cells/lib/ops/writeShellEntrypoint.nix
@@ -44,7 +44,7 @@
   };
 
   mkDebugOCI = entrypoint: name: let
-    debug-banner = nixpkgs.runCommandNoCC "debug-banner" {} ''
+    debug-banner = nixpkgs.runCommand "debug-banner" {} ''
       ${nixpkgs.figlet}/bin/figlet -f banner "STD Debug" > $out
     '';
     debug-tools = with nixpkgs.pkgsStatic; [busybox];

--- a/dogfood.nix
+++ b/dogfood.nix
@@ -31,6 +31,7 @@ growOn {
     # _automation
     (blockTypes.devshells "devshells")
     (blockTypes.nixago "nixago")
+    (blockTypes.containers "containers")
     # (blockTypes.tasks "tasks") # TODO: implement properly
 
     # _tests

--- a/flake.lock
+++ b/flake.lock
@@ -63,11 +63,26 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
         "type": "github"
       },
       "original": {
@@ -79,16 +94,37 @@
     "mdbook-kroki-preprocessor": {
       "flake": false,
       "locked": {
-        "lastModified": 1655670640,
-        "narHash": "sha256-JjqdxftHBjABTkOpFl3cWUJtc/KGwkQ3NRWGLjH2oUs=",
+        "lastModified": 1661755005,
+        "narHash": "sha256-1TJuUzfyMycWlOQH67LR63/ll2GDZz25I3JfScy/Jnw=",
         "owner": "JoelCourtney",
         "repo": "mdbook-kroki-preprocessor",
-        "rev": "bb6e607437ecc3f22fd9036acee6b797a5b45dbc",
+        "rev": "93adb5716d035829efed27f65f2f0833a7d3e76f",
         "type": "github"
       },
       "original": {
         "owner": "JoelCourtney",
         "repo": "mdbook-kroki-preprocessor",
+        "type": "github"
+      }
+    },
+    "n2c": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1665039323,
+        "narHash": "sha256-SAh3ZjFGsaCI8FRzXQyp56qcGdAqgKEfJWPCQ0Sr7tQ=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "b008fe329ffb59b67bf9e7b08ede6ee792f2741a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
         "type": "github"
       }
     },
@@ -120,11 +156,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658311025,
-        "narHash": "sha256-GqagY5YmaZB3YaO41kKcQhe5RcpS83wnsW8iCu5Znqo=",
+        "lastModified": 1665087388,
+        "narHash": "sha256-FZFPuW9NWHJteATOf79rZfwfRn5fE0wi9kRzvGfDHPA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cd8d1784506a7c7eb0796772b73437e0b82fad57",
+        "rev": "95fda953f6db2e9496d2682c4fc7b82f959878f7",
         "type": "github"
       },
       "original": {
@@ -147,9 +183,7 @@
         "microvm": [
           "blank"
         ],
-        "n2c": [
-          "blank"
-        ],
+        "n2c": "n2c",
         "nixago": "nixago",
         "nixpkgs": "nixpkgs",
         "yants": "yants"
@@ -162,11 +196,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1645126146,
-        "narHash": "sha256-XQ1eg4gzXoc7Tl8iXak1uCt3KnsTyxqPtLE+vOoDnrQ=",
+        "lastModified": 1660507851,
+        "narHash": "sha256-BKjq7JnVuUR/xDtcv6Vm9GYGKAblisXrAgybor9hT/s=",
         "owner": "divnix",
         "repo": "yants",
-        "rev": "77df2be1b3cce9f571c6cf451f786b266a6869cc",
+        "rev": "0b895ca02a8fa72bad50b454cb3e7d8a66407c96",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,8 @@
   inputs.dmerge.url = "github:divnix/data-merge";
   inputs.dmerge.inputs.nixlib.follows = "nixpkgs";
   inputs.dmerge.inputs.yants.follows = "yants";
+  inputs.n2c.url = "github:nlewo/nix2container";
+  inputs.n2c.inputs.nixpkgs.follows = "nixpkgs";
   inputs.blank.url = "github:divnix/blank";
   /*
   Auxiliar inputs used in builtin libraries or for the dev environment.
@@ -31,7 +33,6 @@
 
     # Placeholder inputs that can be overloaded via follows
     microvm.follows = "blank";
-    n2c.follows = "blank";
     makes.follows = "blank";
   };
   outputs = inputs: let


### PR DESCRIPTION
This PR introduces support for generating container images that are compatible with [devcontainers](https://code.visualstudio.com/docs/remote/containers). It ingests a devshell and builds a compatible OCI image which can then be invoked as a devcontainer. 