### PR TITLE
book: fix deployed domain

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -30,3 +30,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/book
+          cname: std.divnix.com


### PR DESCRIPTION
The book link keeps breaking because we didn't configure the cname in the action. This should take care of it.