### PR TITLE
fix(presets/lefthook): fail on treefmt changes

### DIFF
--- a/cells/presets/nixago/lefthook.nix
+++ b/cells/presets/nixago/lefthook.nix
@@ -10,8 +10,7 @@
   pre-commit = {
     commands = {
       treefmt = {
-        run = "treefmt {staged_files}";
-        glob = "*";
+        run = "treefmt --fail-on-change {staged_files}";
         skip = ["merge" "rebase"];
       };
     };


### PR DESCRIPTION
Otherwise commit can go through even though staged file are modified by `treefmt`.

Also removed unnecessary glob '*'.