### PR TITLE
feat(presets/lefthook): allow WIP and fixup! commit

### DIFF
--- a/cells/presets/nixago/lefthook.nix
+++ b/cells/presets/nixago/lefthook.nix
@@ -2,7 +2,10 @@
   commit-msg = {
     commands = {
       conform = {
-        run = "conform enforce --commit-msg-file {1}";
+        # allow WIP, fixup!/squash! commits locally
+        run = ''
+          [[ "$(head -n 1 {1})" =~ ^WIP(:.*)?$|^wip(:.*)?$|fixup\!.*|squash\!.* ]] ||
+          conform enforce --commit-msg-file {1}'';
         skip = ["merge" "rebase"];
       };
     };


### PR DESCRIPTION
 workaround https://github.com/siderolabs/conform/issues/225

 Also people very commonly use WIP commits before tidying up, so
 allowing them is probably necessary if we want people not disabling
 conform pre-commit hook.

 Note that this does not affect CI that should ideally still fail on
 WIP commits (TODO: run conform on CI).