### PR TITLE
fix: import nixpkgs from inputs instead

### DIFF
--- a/src/grow.nix
+++ b/src/grow.nix
@@ -189,7 +189,7 @@
           nixpkgs = let
             config = nixpkgsConfig;
           in
-            (import nixpkgs {inherit system config;}) // {inherit (nixpkgs) sourceInfo;};
+            (import inputs.nixpkgs {inherit system config;}) // {inherit (inputs.nixpkgs) sourceInfo;};
         }
       );
       loadCellFor = cellName: let


### PR DESCRIPTION
that's why we got two nixpkgs
![1:3:bash -  NixOS   2022-11-16 21-33-10](https://user-images.githubusercontent.com/21156405/202364509-422021de-717f-4284-aef7-35e74ca6c59b.jpg)
