### PR TITLE
fix: action invocation on the actual git repo

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,22 @@
     arion.follows = "blank";
   };
   outputs = inputs: let
-    blockTypes = import ./src/blocktypes.nix {inherit (inputs) nixpkgs;};
+    blockTypes = import ./src/blocktypes.nix {
+      inherit deSystemize;
+      nixpkgs = builtins.mapAttrs (system: pkgs:
+        pkgs
+        // {
+          writeShellScriptWithPrjRoot = name: content:
+            pkgs.writeShellScript name ''
+              if test -z "$PRJ_ROOT"; then
+                echo "PRJ_ROOT is not set. Action aborting."
+                exit 1
+              fi
+              ${content}
+            '';
+        }
+        inputs.nixpkgs.legacyPackages);
+    };
     deSystemize = inputs.nosys.lib.deSys;
     grow = import ./src/grow.nix {
       inherit (inputs) nixpkgs yants;

--- a/src/blocktypes.nix
+++ b/src/blocktypes.nix
@@ -1,13 +1,16 @@
-{nixpkgs}: {
-  runnables = import ./blocktypes/runnables.nix {inherit nixpkgs;};
-  installables = import ./blocktypes/installables.nix {inherit nixpkgs;};
-  functions = import ./blocktypes/functions.nix {inherit nixpkgs;};
-  data = import ./blocktypes/data.nix {inherit nixpkgs;};
-  devshells = import ./blocktypes/devshells.nix {inherit nixpkgs;};
-  containers = import ./blocktypes/containers.nix {inherit nixpkgs;};
-  files = import ./blocktypes/files.nix {inherit nixpkgs;};
-  microvms = import ./blocktypes/microvms.nix {inherit nixpkgs;};
-  nixago = import ./blocktypes/nixago.nix {inherit nixpkgs;};
-  arion = import ./blocktypes/arion.nix {inherit nixpkgs;};
-  nomadJobManifests = import ./blocktypes/nomadJobManifests.nix {inherit nixpkgs;};
+{
+  nixpkgs,
+  deSystemize,
+}: {
+  runnables = import ./blocktypes/runnables.nix deSystemize nixpkgs;
+  installables = import ./blocktypes/installables.nix deSystemize nixpkgs;
+  functions = import ./blocktypes/functions.nix deSystemize nixpkgs;
+  data = import ./blocktypes/data.nix deSystemize nixpkgs;
+  devshells = import ./blocktypes/devshells.nix deSystemize nixpkgs;
+  containers = import ./blocktypes/containers.nix deSystemize nixpkgs;
+  files = import ./blocktypes/files.nix deSystemize nixpkgs;
+  microvms = import ./blocktypes/microvms.nix deSystemize nixpkgs;
+  nixago = import ./blocktypes/nixago.nix deSystemize nixpkgs;
+  arion = import ./blocktypes/arion.nix deSystemize nixpkgs;
+  nomadJobManifests = import ./blocktypes/nomadJobManifests.nix deSystemize nixpkgs;
 }

--- a/src/blocktypes/actions/build.nix
+++ b/src/blocktypes/actions/build.nix
@@ -1,7 +1,7 @@
-fragment: {
+writeShellScriptWithPrjRoot: fragment: {
   name = "build";
   description = "build this target";
-  command = ''
+  command = writeShellScriptWithPrjRoot "build" ''
     nix build "$PRJ_ROOT#${fragment}
   '';
 }

--- a/src/blocktypes/actions/build.nix
+++ b/src/blocktypes/actions/build.nix
@@ -1,7 +1,7 @@
-flake: fragment: {
+fragment: {
   name = "build";
   description = "build this target";
   command = ''
-    nix build ${flake}#${fragment}
+    nix build "$PRJ_ROOT#${fragment}
   '';
 }

--- a/src/blocktypes/arion.nix
+++ b/src/blocktypes/arion.nix
@@ -1,5 +1,4 @@
-{nixpkgs}: let
-  l = nixpkgs.lib // builtins;
+deSystemize: nixpkgs': let
   /*
   Use the arion for arionCompose Jobs - https://docs.hercules-ci.com/arion/
 
@@ -19,47 +18,49 @@
       fragment,
       fragmentRelPath,
     }: let
+      l = nixpkgs.lib // builtins;
+      nixpkgs = deSystemize system nixpkgs'.legacyPackages;
       cmd = "arion --prebuilt-file $(nix build $PRJ_ROOT#${fragment}.config.out.dockerComposeYaml --print-out-paths)";
     in [
       {
         name = "up";
         description = "arion up";
-        command = ''
+        command = nixpkgs.writeShellScriptWithPrjRoot "up" ''
           ${cmd} up "$@"
         '';
       }
       {
         name = "ps";
         description = "exec this arion task to ps";
-        command = ''
+        command = nixpkgs.writeShellScriptWithPrjRoot "ps" ''
           ${cmd} ps "$@"
         '';
       }
       {
         name = "stop";
         description = "arion stop";
-        command = ''
+        command = nixpkgs.writeShellScriptWithPrjRoot "stop" ''
           ${cmd} stop "$@"
         '';
       }
       {
         name = "rm";
         description = "arion rm";
-        command = ''
+        command = nixpkgs.writeShellScriptWithPrjRoot "rm" ''
           ${cmd} rm "$@"
         '';
       }
       {
         name = "config";
         description = "check the docker-compose yaml file";
-        command = ''
+        command = nixpkgs.writeShellScriptWithPrjRoot "config" ''
           ${cmd} config "$@"
         '';
       }
       {
         name = "arion";
         description = "pass any command to arion";
-        command = ''
+        command = nixpkgs.writeShellScriptWithPrjRoot "arion" ''
           ${cmd} "$@"
         '';
       }

--- a/src/blocktypes/arion.nix
+++ b/src/blocktypes/arion.nix
@@ -16,11 +16,10 @@
     type = "arion";
     actions = {
       system,
-      flake,
       fragment,
       fragmentRelPath,
     }: let
-      cmd = "arion --prebuilt-file $(nix build ${flake}#${fragment}.config.out.dockerComposeYaml --print-out-paths)";
+      cmd = "arion --prebuilt-file $(nix build $PRJ_ROOT#${fragment}.config.out.dockerComposeYaml --print-out-paths)";
     in [
       {
         name = "up";

--- a/src/blocktypes/containers.nix
+++ b/src/blocktypes/containers.nix
@@ -15,45 +15,44 @@
     type = "containers";
     actions = {
       system,
-      flake,
       fragment,
       fragmentRelPath,
     }: [
-      (import ./actions/build.nix flake fragment)
+      (import ./actions/build.nix fragment)
       {
         name = "print-image";
         description = "print out the image name & tag";
         command = ''
           echo
-          echo "$(nix eval --raw ${flake}#${fragment}.imageName):$(nix eval --raw ${flake}#${fragment}.imageTag)"
+          echo "$(nix eval --raw "$PRJ_ROOT#${fragment}.imageName):$(nix eval --raw "$PRJ_ROOT#${fragment}.imageTag)"
         '';
       }
       {
         name = "publish";
         description = "copy the image to its remote registry";
         command = ''
-          nix run ${flake}#${fragment}.copyToRegistry
+          nix run "$PRJ_ROOT#${fragment}.copyToRegistry
         '';
       }
       {
         name = "copy-to-registry";
         description = "copy the image to its remote registry";
         command = ''
-          nix run ${flake}#${fragment}.copyToRegistry
+          nix run "$PRJ_ROOT#${fragment}.copyToRegistry
         '';
       }
       {
         name = "copy-to-docker";
         description = "copy the image to the local docker registry";
         command = ''
-          nix run ${flake}#${fragment}.copyToDockerDaemon
+          nix run "$PRJ_ROOT#${fragment}.copyToDockerDaemon
         '';
       }
       {
         name = "copy-to-podman";
         description = "copy the image to the local podman registry";
         command = ''
-          nix run ${flake}#${fragment}.copyToPodman
+          nix run "$PRJ_ROOT#${fragment}.copyToPodman
         '';
       }
     ];

--- a/src/blocktypes/data.nix
+++ b/src/blocktypes/data.nix
@@ -16,7 +16,6 @@
     type = "data";
     actions = {
       system,
-      flake,
       fragment,
       fragmentRelPath,
     }: let
@@ -26,7 +25,7 @@
       expr = l.strings.escapeShellArg ''
         let
           pkgs = (builtins.getFlake "${nixpkgs.sourceInfo.outPath}").legacyPackages.${system};
-          this = (builtins.getFlake "${flake}").${fragment};
+          this = (builtins.getFlake "$PRJ_ROOT").${fragment};
         in
           pkgs.writeTextFile {
             name = "data.json";

--- a/src/blocktypes/devshells.nix
+++ b/src/blocktypes/devshells.nix
@@ -1,5 +1,4 @@
-{nixpkgs}: let
-  l = nixpkgs.lib // builtins;
+deSystemize: nixpkgs': let
   /*
   Use the Devshells Blocktype for devShells.
 
@@ -15,12 +14,15 @@
       system,
       fragment,
       fragmentRelPath,
-    }: [
-      (import ./actions/build.nix fragment)
+    }: let
+      l = nixpkgs.lib // builtins;
+      nixpkgs = deSystemize system nixpkgs'.legacyPackages;
+    in [
+      (import ./actions/build.nix nixpkgs.writeShellScriptWithPrjRoot fragment)
       {
         name = "enter";
         description = "enter this devshell";
-        command = ''
+        command = nixpkgs.writeShellScriptWithPrjRoot "enter" ''
           std_layout_dir=$PRJ_ROOT/.std
           profile_path="$std_layout_dir/${fragmentRelPath}"
           mkdir -p "$profile_path"

--- a/src/blocktypes/devshells.nix
+++ b/src/blocktypes/devshells.nix
@@ -13,11 +13,10 @@
     type = "devshells";
     actions = {
       system,
-      flake,
       fragment,
       fragmentRelPath,
     }: [
-      (import ./actions/build.nix flake fragment)
+      (import ./actions/build.nix fragment)
       {
         name = "enter";
         description = "enter this devshell";

--- a/src/blocktypes/files.nix
+++ b/src/blocktypes/files.nix
@@ -11,11 +11,10 @@
     type = "files";
     actions = {
       system,
-      flake,
       fragment,
       fragmentRelPath,
     }: let
-      builder = ["nix" "build" "--impure" "--json" "--no-link" "${flake}#${fragment}"];
+      builder = ["nix" "build" "--impure" "--json" "--no-link" "$PRJ_ROOT#${fragment}"];
       jq = ["|" "${nixpkgs.legacyPackages.${system}.jq}/bin/jq" "-r" "'.[].outputs.out'"];
       bat = ["${nixpkgs.legacyPackages.${system}.bat}/bin/bat"];
     in [

--- a/src/blocktypes/files.nix
+++ b/src/blocktypes/files.nix
@@ -1,5 +1,4 @@
-{nixpkgs}: let
-  l = nixpkgs.lib // builtins;
+deSystemize: nixpkgs': let
   /*
   Use the Files Blocktype for any text data.
 
@@ -14,14 +13,16 @@
       fragment,
       fragmentRelPath,
     }: let
+      l = nixpkgs.lib // builtins;
+      nixpkgs = deSystemize system nixpkgs'.legacyPackages;
       builder = ["nix" "build" "--impure" "--json" "--no-link" "$PRJ_ROOT#${fragment}"];
-      jq = ["|" "${nixpkgs.legacyPackages.${system}.jq}/bin/jq" "-r" "'.[].outputs.out'"];
-      bat = ["${nixpkgs.legacyPackages.${system}.bat}/bin/bat"];
+      jq = ["|" "${nixpkgs.jq}/bin/jq" "-r" "'.[].outputs.out'"];
+      bat = ["${nixpkgs.bat}/bin/bat"];
     in [
       {
         name = "explore";
         description = "interactively explore with bat";
-        command = l.concatStringsSep "\t" (bat ++ ["$("] ++ builder ++ jq ++ [")"]);
+        command = nixpkgs.writeShellScriptWithPrjRoot "explore" (l.concatStringsSep "\t" (bat ++ ["$("] ++ builder ++ jq ++ [")"]));
       }
     ];
   };

--- a/src/blocktypes/functions.nix
+++ b/src/blocktypes/functions.nix
@@ -1,5 +1,4 @@
-{nixpkgs}: let
-  l = nixpkgs.lib // builtins;
+deSystemize: nixpkgs': let
   /*
   Use the Functions Blocktype for reusable nix functions that you would
   call elswhere in the code.

--- a/src/blocktypes/installables.nix
+++ b/src/blocktypes/installables.nix
@@ -1,5 +1,4 @@
-{nixpkgs}: let
-  l = nixpkgs.lib // builtins;
+deSystemize: nixpkgs': let
   /*
   Use the Installables Blocktype for targets that you want to
   make availabe for installation into the user's nix profile.
@@ -21,47 +20,50 @@
       system,
       fragment,
       fragmentRelPath,
-    }: [
-      (import ./actions/build.nix fragment)
+    }: let
+      l = nixpkgs.lib // builtins;
+      nixpkgs = deSystemize system nixpkgs'.legacyPackages;
+    in [
+      (import ./actions/build.nix nixpkgs.writeShellScriptWithPrjRoot fragment)
       {
         name = "install";
         description = "install this target";
-        command = ''
+        command = nixpkgs.writeShellScriptWithPrjRoot "install" ''
           nix profile install "$PRJ_ROOT#${fragment}
         '';
       }
       {
         name = "upgrade";
         description = "upgrade this target";
-        command = ''
+        command = nixpkgs.writeShellScriptWithPrjRoot "upgrade" ''
           nix profile upgrade "$PRJ_ROOT#${fragment}
         '';
       }
       {
         name = "remove";
         description = "remove this target";
-        command = ''
+        command = nixpkgs.writeShellScriptWithPrjRoot "remove" ''
           nix profile remove "$PRJ_ROOT#${fragment}
         '';
       }
       {
         name = "bundle";
         description = "bundle this target";
-        command = ''
+        command = nixpkgs.writeShellScriptWithPrjRoot "bundle" ''
           nix bundle --bundler github:Ninlives/relocatable.nix --refresh "$PRJ_ROOT#${fragment}
         '';
       }
       {
         name = "bundleImage";
         description = "bundle this target to image";
-        command = ''
+        command = nixpkgs.writeShellScriptWithPrjRoot "bundleImage" ''
           nix bundle --bundler github:NixOS/bundlers#toDockerImage --refresh "$PRJ_ROOT#${fragment}
         '';
       }
       {
         name = "bundleAppImage";
         description = "bundle this target to AppImage";
-        command = ''
+        command = nixpkgs.writeShellScriptWithPrjRoot "bundleAppImage" ''
           nix bundle --bundler github:ralismark/nix-appimage --refresh "$PRJ_ROOT#${fragment}
         '';
       }

--- a/src/blocktypes/installables.nix
+++ b/src/blocktypes/installables.nix
@@ -19,51 +19,50 @@
     type = "installables";
     actions = {
       system,
-      flake,
       fragment,
       fragmentRelPath,
     }: [
-      (import ./actions/build.nix flake fragment)
+      (import ./actions/build.nix fragment)
       {
         name = "install";
         description = "install this target";
         command = ''
-          nix profile install ${flake}#${fragment}
+          nix profile install "$PRJ_ROOT#${fragment}
         '';
       }
       {
         name = "upgrade";
         description = "upgrade this target";
         command = ''
-          nix profile upgrade ${flake}#${fragment}
+          nix profile upgrade "$PRJ_ROOT#${fragment}
         '';
       }
       {
         name = "remove";
         description = "remove this target";
         command = ''
-          nix profile remove ${flake}#${fragment}
+          nix profile remove "$PRJ_ROOT#${fragment}
         '';
       }
       {
         name = "bundle";
         description = "bundle this target";
         command = ''
-          nix bundle --bundler github:Ninlives/relocatable.nix --refresh ${flake}#${fragment}
+          nix bundle --bundler github:Ninlives/relocatable.nix --refresh "$PRJ_ROOT#${fragment}
         '';
       }
       {
         name = "bundleImage";
         description = "bundle this target to image";
         command = ''
-          nix bundle --bundler github:NixOS/bundlers#toDockerImage --refresh ${flake}#${fragment}
+          nix bundle --bundler github:NixOS/bundlers#toDockerImage --refresh "$PRJ_ROOT#${fragment}
         '';
       }
       {
         name = "bundleAppImage";
         description = "bundle this target to AppImage";
         command = ''
-          nix bundle --bundler github:ralismark/nix-appimage --refresh ${flake}#${fragment}
+          nix bundle --bundler github:ralismark/nix-appimage --refresh "$PRJ_ROOT#${fragment}
         '';
       }
     ];

--- a/src/blocktypes/microvms.nix
+++ b/src/blocktypes/microvms.nix
@@ -1,5 +1,4 @@
-{nixpkgs}: let
-  l = nixpkgs.lib // builtins;
+deSystemize: nixpkgs': let
   /*
   Use the Microvms Blocktype for Microvm.nix - https://github.com/astro/microvm.nix
 
@@ -17,16 +16,19 @@
       fragment,
       fragmentRelPath,
     }: let
+      l = nixpkgs.lib // builtins;
+      nixpkgs = deSystemize system nixpkgs'.legacyPackages;
       run = ["nix" "run" "$PRJ_ROOT#${fragment}.config.microvm.runner"];
     in [
       {
         name = "microvm";
         description = "exec this microvm";
-        command =
+        command = nixpkgs.writeShellScriptWithPrjRoot "microvm" (
           (l.concatStringsSep "\t" run)
           + ".$(nix eval --json --option warn-dirty false\ "
           + "$PRJ_ROOT#${fragment}.config.microvm.hypervisor)"
-          + "\ ${substituters} ${keys}";
+          + "\ ${substituters} ${keys}"
+        );
       }
     ];
   };

--- a/src/blocktypes/microvms.nix
+++ b/src/blocktypes/microvms.nix
@@ -14,11 +14,10 @@
     type = "microvms";
     actions = {
       system,
-      flake,
       fragment,
       fragmentRelPath,
     }: let
-      run = ["nix" "run" "${flake}#${fragment}.config.microvm.runner"];
+      run = ["nix" "run" "$PRJ_ROOT#${fragment}.config.microvm.runner"];
     in [
       {
         name = "microvm";
@@ -26,7 +25,7 @@
         command =
           (l.concatStringsSep "\t" run)
           + ".$(nix eval --json --option warn-dirty false\ "
-          + "${flake}#${fragment}.config.microvm.hypervisor)"
+          + "$PRJ_ROOT#${fragment}.config.microvm.hypervisor)"
           + "\ ${substituters} ${keys}";
       }
     ];

--- a/src/blocktypes/nixago.nix
+++ b/src/blocktypes/nixago.nix
@@ -19,7 +19,6 @@
     type = "nixago";
     actions = {
       system,
-      flake,
       fragment,
       fragmentRelPath,
     }: [
@@ -27,14 +26,14 @@
         name = "populate";
         description = "populate this nixago file into the repo";
         command = ''
-          nix run ${flake}#${fragment}.install
+          nix run "$PRJ_ROOT#${fragment}.install
         '';
       }
       {
         name = "explore";
         description = "interactively explore the nixago file";
         command = ''
-          ${nixpkgs.legacyPackages.${system}.bat}/bin/bat "$(nix build --no-link --print-out-paths ${flake}#${fragment}.configFile)"
+          ${nixpkgs.legacyPackages.${system}.bat}/bin/bat "$(nix build --no-link --print-out-paths "$PRJ_ROOT#${fragment}.configFile)"
         '';
       }
     ];

--- a/src/blocktypes/nixago.nix
+++ b/src/blocktypes/nixago.nix
@@ -1,5 +1,4 @@
-{nixpkgs}: let
-  l = nixpkgs.lib // builtins;
+deSystemize: nixpkgs': let
   /*
   Use the Nixago Blocktype for nixago pebbles.
 
@@ -21,19 +20,22 @@
       system,
       fragment,
       fragmentRelPath,
-    }: [
+    }: let
+      l = nixpkgs.lib // builtins;
+      nixpkgs = deSystemize system nixpkgs'.legacyPackages;
+    in [
       {
         name = "populate";
         description = "populate this nixago file into the repo";
-        command = ''
+        command = nixpkgs.writeShellScriptWithPrjRoot "populate" ''
           nix run "$PRJ_ROOT#${fragment}.install
         '';
       }
       {
         name = "explore";
         description = "interactively explore the nixago file";
-        command = ''
-          ${nixpkgs.legacyPackages.${system}.bat}/bin/bat "$(nix build --no-link --print-out-paths "$PRJ_ROOT#${fragment}.configFile)"
+        command = nixpkgs.writeShellScriptWithPrjRoot "explore" ''
+          ${nixpkgs.bat}/bin/bat "$(nix build --no-link --print-out-paths "$PRJ_ROOT#${fragment}.configFile)"
         '';
       }
     ];

--- a/src/blocktypes/nomadJobManifests.nix
+++ b/src/blocktypes/nomadJobManifests.nix
@@ -1,5 +1,4 @@
-{nixpkgs}: let
-  l = nixpkgs.lib // builtins;
+deSystemize: nixpkgs': let
   /*
   Use the `nomadJobsManifest` Blocktype for rendering job descriptions
   for the Nomad Cluster scheduler. Each named attribtute-set under the
@@ -19,9 +18,11 @@
       fragment,
       fragmentRelPath,
     }: let
-      fx = "${nixpkgs.legacyPackages.${system}.fx}/bin";
-      nomad = "${nixpkgs.legacyPackages.${system}.nomad}/bin";
-      jq = "${nixpkgs.legacyPackages.${system}.jq}/bin";
+      l = nixpkgs.lib // builtins;
+      nixpkgs = deSystemize system nixpkgs'.legacyPackages;
+      fx = "${nixpkgs.fx}/bin";
+      nomad = "${nixpkgs.nomad}/bin";
+      jq = "${nixpkgs.jq}/bin";
       nixExpr = ''
         x: let
           job = builtins.mapAttrs (_: v: v // {meta = v.meta or {} // {rev = "\"$(git rev-parse --short HEAD)\"";};}) x.job;
@@ -60,6 +61,7 @@
         name = "render";
         description = "build the JSON job description";
         command =
+          nixpkgs.writeShellScriptWithPrjRoot "render"
           # bash
           ''
             set -e
@@ -73,6 +75,7 @@
         name = "deploy";
         description = "Deploy the job to Nomad";
         command =
+          nixpkgs.writeShellScriptWithPrjRoot "deploy"
           # bash
           ''
             set -e
@@ -115,6 +118,7 @@
         name = "explore";
         description = "interactively explore the Job defintion";
         command =
+          nixpkgs.writeShellScriptWithPrjRoot "explore"
           # bash
           ''
             set -e

--- a/src/blocktypes/nomadJobManifests.nix
+++ b/src/blocktypes/nomadJobManifests.nix
@@ -16,7 +16,6 @@
 
     actions = {
       system,
-      flake,
       fragment,
       fragmentRelPath,
     }: let
@@ -39,7 +38,7 @@
       render = ''
         echo "Rendering to $job_path..."
 
-        # use `.` instead of ${flake} to capture dirty state
+        # use `.` instead of "$PRJ_ROOT to capture dirty state
         if ! out="$(nix eval --no-allow-dirty --raw .\#${fragment} --apply "${nixExpr}")"; then
           >&2 echo "error: Will not render jobs from a dirty tree, otherwise we cannot keep good track of deployment history."
           exit 1

--- a/src/blocktypes/runnables.nix
+++ b/src/blocktypes/runnables.nix
@@ -10,16 +10,15 @@
     type = "runnables";
     actions = {
       system,
-      flake,
       fragment,
       fragmentRelPath,
     }: [
-      (import ./actions/build.nix flake fragment)
+      (import ./actions/build.nix fragment)
       {
         name = "run";
         description = "exec this target";
         command = ''
-          nix run ${flake}#${fragment} -- "$@"
+          nix run "$PRJ_ROOT#${fragment} -- "$@"
         '';
       }
     ];

--- a/src/blocktypes/runnables.nix
+++ b/src/blocktypes/runnables.nix
@@ -1,5 +1,4 @@
-{nixpkgs}: let
-  l = nixpkgs.lib // builtins;
+deSystemize: nixpkgs': let
   /*
   Use the Runnables Blocktype for targets that you want to
   make accessible with a 'run' action on the TUI.
@@ -12,12 +11,14 @@
       system,
       fragment,
       fragmentRelPath,
-    }: [
-      (import ./actions/build.nix fragment)
+    }: let
+      nixpkgs = deSystemize system nixpkgs'.legacyPackages;
+    in [
+      (import ./actions/build.nix nixpkgs.writeShellScriptWithPrjRoot fragment)
       {
         name = "run";
         description = "exec this target";
-        command = ''
+        command = nixpkgs.writeShellScriptWithPrjRoot "run" ''
           nix run "$PRJ_ROOT#${fragment} -- "$@"
         '';
       }

--- a/src/grow.nix
+++ b/src/grow.nix
@@ -216,7 +216,6 @@
               then
                 cellBlock.actions {
                   inherit system;
-                  flake = inputs.self.sourceInfo.outPath;
                   fragment = targetFragment;
                   fragmentRelPath = "${cellName}/${cellBlock.name}/${name}";
                 }

--- a/src/grow.nix
+++ b/src/grow.nix
@@ -257,13 +257,7 @@
               inherit name;
               value = l.listToAttrs (map (a: {
                   inherit (a) name;
-                  value = nixpkgs.legacyPackages.${system}.writeShellScript a.name ''
-                    if test -z "$PRJ_ROOT"; then
-                      echo "PRJ_ROOT is not set. Action aborting."
-                      exit 1
-                    fi
-                    ${a.command}
-                  '';
+                  value = a.command;
                 })
                 actions);
             };

--- a/src/grow.nix
+++ b/src/grow.nix
@@ -257,7 +257,13 @@
               inherit name;
               value = l.listToAttrs (map (a: {
                   inherit (a) name;
-                  value = nixpkgs.legacyPackages.${system}.writeShellScript a.name a.command;
+                  value = nixpkgs.legacyPackages.${system}.writeShellScript a.name ''
+                    if test -z "$PRJ_ROOT"; then
+                      echo "PRJ_ROOT is not set. Action aborting."
+                      exit 1
+                    fi
+                    ${a.command}
+                  '';
                 })
                 actions);
             };

--- a/src/validators.nix
+++ b/src/validators.nix
@@ -74,7 +74,6 @@ in {
       ci = option (attrs bool);
       actions = option (functionWithArgs {
         system = false;
-        flake = false;
         fragment = false;
         fragmentRelPath = false;
       });


### PR DESCRIPTION
using the flake output derivation effectively invokes nix
commands on a source copy that isn't a git repository anymore
hence `self.rev` does not exists. That means that any intentional
use of `self.rev` was sabotaged by the use of std actions.
