### PR TITLE
feat(actions): pass the target into the actions

### DIFF
--- a/cells/std/cli/env.go
+++ b/cells/std/cli/env.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// PRJ_ROOT is a useful environment contract prototyped by `numtide/devshell`
+// TODO: coordinate with `numtide` about PRJ Base Directory Specification
+const (
+	PRJ_ROOT          = "PRJ_ROOT"
+	PRJ_DATA_DIR      = "PRJ_DATA_DIR"
+	PRJ_CACHE_DIR     = "PRJ_CACHE_DIR"
+	NIX_CONFIG        = "NIX_CONFIG"
+	prjRootGitCmd     = "git rev-parse --show-toplevel"
+	prjDataDirTmpl    = "%s/.std"
+	prjCacheDirTmpl   = "%s/.std/cache"
+	prjLastActionTmpl = "%s/.std/last-action"
+)
+
+func setEnv() (string, string, string, string, error) {
+	var prjRoot string
+	prjRoot, present := os.LookupEnv(PRJ_ROOT)
+	if !present {
+		args := strings.Fields(prjRootGitCmd)
+		prjRootB, err := exec.Command(args[0], args[1:]...).Output()
+		prjRootB = bytes.TrimRight(prjRootB, "\n")
+		prjRoot = string(prjRootB[:])
+		if err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				return "", "", "", "", fmt.Errorf("%w, stderr:\n%s", exitErr, exitErr.Stderr)
+			}
+			return "", "", "", "", err
+		}
+
+		os.Setenv(PRJ_ROOT, prjRoot)
+	}
+	prjDataDir, present := os.LookupEnv(PRJ_DATA_DIR)
+	if !present {
+		prjDataDir = fmt.Sprintf(prjDataDirTmpl, prjRoot)
+		os.Setenv(PRJ_DATA_DIR, prjDataDir)
+	}
+	prjCacheDir, present := os.LookupEnv(PRJ_CACHE_DIR)
+	if !present {
+		prjCacheDir = fmt.Sprintf(prjCacheDirTmpl, prjRoot)
+		os.Setenv(PRJ_CACHE_DIR, prjCacheDir)
+	}
+	nixConfigEnv, present := os.LookupEnv(NIX_CONFIG)
+	if !present {
+		os.Setenv(NIX_CONFIG, extraNixConfig)
+	} else {
+		os.Setenv(NIX_CONFIG, fmt.Sprintf("%s\n%s", nixConfigEnv, extraNixConfig))
+	}
+	return prjRoot, prjDataDir, prjCacheDir, fmt.Sprintf(prjLastActionTmpl, prjRoot), nil
+}

--- a/cells/std/cli/main.go
+++ b/cells/std/cli/main.go
@@ -18,9 +18,11 @@ var buildCommit = "dirty"
 // PRJ_ROOT is a useful environment contract prototyped by `numtide/devshell`
 // TODO: coordinate with `numtide` about PRJ Base Directory Specification
 const (
-	PRJ_ROOT      = "PRJ_ROOT"
-	NIX_CONFIG    = "NIX_CONFIG"
-	prjRootGitCmd = "git rev-parse --show-toplevel"
+	PRJ_ROOT       = "PRJ_ROOT"
+	PRJ_DATA_DIR   = "PRJ_DATA_DIR"
+	NIX_CONFIG     = "NIX_CONFIG"
+	prjRootGitCmd  = "git rev-parse --show-toplevel"
+	prjDataDirTmpl = "%s/.std"
 )
 
 // extraNixConfig implements quality of life flags for the nix command invocation
@@ -55,6 +57,11 @@ func bashExecve(command []string, cmdArgs []string) error {
 
 		os.Setenv(PRJ_ROOT, prjRoot)
 	}
+	prjDataDir, present := os.LookupEnv(PRJ_DATA_DIR)
+	if !present {
+		prjDataDir = fmt.Sprintf(prjDataDirTmpl, prjRoot)
+		os.Setenv(PRJ_DATA_DIR, prjDataDir)
+	}
 	nixConfigEnv, present := os.LookupEnv(NIX_CONFIG)
 	if !present {
 		os.Setenv(NIX_CONFIG, extraNixConfig)
@@ -63,9 +70,9 @@ func bashExecve(command []string, cmdArgs []string) error {
 	}
 	env := os.Environ()
 	args := []string{"bash", "-c", fmt.Sprintf(
-		"%s && %s/.std/last-action %s",
+		"%s && %s/last-action %s",
 		strings.Join(command, " "),
-		prjRoot,
+		prjDataDir,
 		strings.Join(cmdArgs, " "),
 	),
 	}

--- a/cells/std/lib/default.nix
+++ b/cells/std/lib/default.nix
@@ -38,4 +38,6 @@ in
       ../lib/ops/mkMicrovm.nix {
         inputs = requireInput {inputs = inputs';} "makes" "github:fluidattacks/makes" "std.std.lib.fromMakesWith";
       };
+
+    mkDevelopDrv = import "${inputs.self}/src/devshell-drv.nix";
   }

--- a/deprecation.nix
+++ b/deprecation.nix
@@ -1,27 +1,6 @@
 inputs: let
   removeBy = import ./cells/std/errors/removeBy.nix {inherit inputs;};
 in {
-  warnOrganelles = project:
-    removeBy "October 2022" ''
-
-      "organelle" nomenclature is deprecated.
-
-      Please rename:
-
-      - sed -i 's/organelles/cellBlocks/g'
-      - sed -i 's/organelle/cellBlock/g'
-      - sed -i 's/Organelles/Cell Blocks/g'
-      - sed -i 's/Organelle/Cell Block/g'
-
-      There is an old revision of `std` in the evaluation path
-      in project: ${toString project}
-
-      Please review your code base and/or inform upstream to
-      update their version of Standard ASAP.
-
-      see: https://github.com/divnix/std/issues/116
-    '';
-
   warnRemovedDevshellOptionAdr = removeBy "December 2022" ''
     The std.adr.enable option has been removed from the std shell.
     Please look for something like "adr.enable = false" and drop it.
@@ -68,4 +47,17 @@ in {
 
     Please consult its documentation.
   '';
+
+  warnOldActionInterface = actions:
+    removeBy "March 2022" ''
+
+      The action interface has chaged from:
+        { system, flake, fragment, fragmentRelPath }
+      To:
+        { system, target, fragment, fragmentRelPath }
+
+      Please adjust the following actions:
+
+      ${builtins.concatStringsSep "\n" (map (a: " - ${a.name}: ${(builtins.unsafeGetAttrPos "name" a).file}") actions)}
+    '';
 }

--- a/direnv_lib.sh
+++ b/direnv_lib.sh
@@ -5,7 +5,7 @@
 
 # re-branding & force congruent choice with `std` CLI
 direnv_layout_dir=$(git rev-parse --show-toplevel)/.std
-PRJ_ROOT=${direnv_layout_dir%/*}
+PRJ_ROOT="${direnv_layout_dir%/*}"
 export PRJ_ROOT
 
 # nicer dienv & nixago output styling

--- a/direnv_lib.sh
+++ b/direnv_lib.sh
@@ -6,7 +6,9 @@
 # re-branding & force congruent choice with `std` CLI
 direnv_layout_dir=$(git rev-parse --show-toplevel)/.std
 PRJ_ROOT="${direnv_layout_dir%/*}"
+PRJ_DATA_DIR="${direnv_layout_dir}"
 export PRJ_ROOT
+export PRJ_DATA_DIR
 
 # nicer dienv & nixago output styling
 export DIRENV_LOG_FORMAT=$'\E[mdirenv: \E[38;5;8m%s\E[m'

--- a/direnv_lib.sh
+++ b/direnv_lib.sh
@@ -5,6 +5,8 @@
 
 # re-branding & force congruent choice with `std` CLI
 direnv_layout_dir=$(git rev-parse --show-toplevel)/.std
+PRJ_ROOT=${direnv_layout_dir%/*}
+export PRJ_ROOT
 
 # nicer dienv & nixago output styling
 export DIRENV_LOG_FORMAT=$'\E[mdirenv: \E[38;5;8m%s\E[m'
@@ -63,8 +65,9 @@ use_std() {
 
   mkdir -p "$(direnv_layout_dir)/$block/$organ/$target"
 
-  nix build "$PWD#$system.$block.$organ.$target" "${nix_args[@]}" --profile "$profile_path/shell-profile"
-  . "$profile_path/shell-profile/entrypoint"
+  enter="$(nix build "$PWD#__std.actions.$system.$block.$organ.$target.enter" "${nix_args[@]}" --print-out-paths --profile "$profile_path/enter-action")"
+  export STD_DIRENV=1
+  eval "$(<"$enter")"
   # this is not true
-  unset IN_NIX_SHELL
+  unset IN_NIX_SHELL STD_DIRENV
 }

--- a/direnv_lib.sh
+++ b/direnv_lib.sh
@@ -7,8 +7,10 @@
 direnv_layout_dir=$(git rev-parse --show-toplevel)/.std
 PRJ_ROOT="${direnv_layout_dir%/*}"
 PRJ_DATA_DIR="${direnv_layout_dir}"
+PRJ_CACHE_DIR="${direnv_layout_dir}/cache"
 export PRJ_ROOT
 export PRJ_DATA_DIR
+export PRJ_CACHE_DIR
 
 # nicer dienv & nixago output styling
 export DIRENV_LOG_FORMAT=$'\E[mdirenv: \E[38;5;8m%s\E[m'

--- a/src/blocktypes/actions/build.nix
+++ b/src/blocktypes/actions/build.nix
@@ -1,7 +1,8 @@
-flake: fragment: {
+drv: {
   name = "build";
   description = "build this target";
   command = ''
-    nix build ${flake}#${fragment}
+    # ${drv}
+    nix build ${builtins.unsafeDiscardStringContext drv.drvPath}
   '';
 }

--- a/src/blocktypes/actions/run.nix
+++ b/src/blocktypes/actions/run.nix
@@ -1,0 +1,18 @@
+{
+  lib,
+  target,
+}: let
+  name = lib.removeSuffix "-${target.version or ""}" target.name;
+
+  programName =
+    target.meta.mainProgram
+    or target.pname
+    or name;
+
+  run =
+    # this is the exact sequence mentioned by the `nix run` docs
+    # and so should be compatible
+    target.program
+    or "${target}/bin/${programName}";
+in
+  run

--- a/src/blocktypes/actions/run.nix
+++ b/src/blocktypes/actions/run.nix
@@ -2,12 +2,11 @@
   lib,
   target,
 }: let
-  name = lib.removeSuffix "-${target.version or ""}" target.name;
+  name = lib.getName;
 
   programName =
     target.meta.mainProgram
-    or target.pname
-    or name;
+    or (lib.getName target);
 
   run =
     # this is the exact sequence mentioned by the `nix run` docs

--- a/src/blocktypes/arion.nix
+++ b/src/blocktypes/arion.nix
@@ -16,7 +16,6 @@
     type = "arion";
     actions = {
       system,
-      flake,
       fragment,
       fragmentRelPath,
       target,

--- a/src/blocktypes/arion.nix
+++ b/src/blocktypes/arion.nix
@@ -19,6 +19,7 @@
       flake,
       fragment,
       fragmentRelPath,
+      target,
     }: let
       cmd = "arion --prebuilt-file $(nix build ${flake}#${fragment}.config.out.dockerComposeYaml --print-out-paths)";
     in [

--- a/src/blocktypes/arion.nix
+++ b/src/blocktypes/arion.nix
@@ -21,7 +21,7 @@
       fragmentRelPath,
       target,
     }: let
-      cmd = "arion --prebuilt-file $(nix build ${flake}#${fragment}.config.out.dockerComposeYaml --print-out-paths)";
+      cmd = "arion --prebuilt-file ${target.config.out.dockerComposeYaml}";
     in [
       {
         name = "up";

--- a/src/blocktypes/containers.nix
+++ b/src/blocktypes/containers.nix
@@ -20,13 +20,13 @@
       fragmentRelPath,
       target,
     }: [
-      (import ./actions/build.nix flake fragment)
+      (import ./actions/build.nix target)
       {
         name = "print-image";
         description = "print out the image name & tag";
         command = ''
           echo
-          echo "$(nix eval --raw ${flake}#${fragment}.imageName):$(nix eval --raw ${flake}#${fragment}.imageTag)"
+          echo "${target.imageName}:${target.imageTag}"
         '';
       }
       {
@@ -40,21 +40,21 @@
         name = "copy-to-registry";
         description = "copy the image to its remote registry";
         command = ''
-          nix run ${flake}#${fragment}.copyToRegistry
+          ${target.copyToRegistry}/bin/copy-to-registry
         '';
       }
       {
         name = "copy-to-docker";
         description = "copy the image to the local docker registry";
         command = ''
-          nix run ${flake}#${fragment}.copyToDockerDaemon
+          ${target.copyToDockerDaemon}/bin/copy-to-docker-daemon
         '';
       }
       {
         name = "copy-to-podman";
         description = "copy the image to the local podman registry";
         command = ''
-          nix run ${flake}#${fragment}.copyToPodman
+          ${target.copyToPodman}/bin/copy-to-podman
         '';
       }
     ];

--- a/src/blocktypes/containers.nix
+++ b/src/blocktypes/containers.nix
@@ -15,7 +15,6 @@
     type = "containers";
     actions = {
       system,
-      flake,
       fragment,
       fragmentRelPath,
       target,

--- a/src/blocktypes/containers.nix
+++ b/src/blocktypes/containers.nix
@@ -18,6 +18,7 @@
       flake,
       fragment,
       fragmentRelPath,
+      target,
     }: [
       (import ./actions/build.nix flake fragment)
       {
@@ -32,7 +33,7 @@
         name = "publish";
         description = "copy the image to its remote registry";
         command = ''
-          nix run ${flake}#${fragment}.copyToRegistry
+          ${target.copyToRegistry}/bin/copy-to-registry
         '';
       }
       {

--- a/src/blocktypes/data.nix
+++ b/src/blocktypes/data.nix
@@ -16,7 +16,6 @@
     type = "data";
     actions = {
       system,
-      flake,
       fragment,
       fragmentRelPath,
       target,

--- a/src/blocktypes/data.nix
+++ b/src/blocktypes/data.nix
@@ -19,6 +19,7 @@
       flake,
       fragment,
       fragmentRelPath,
+      target,
     }: let
       builder = ["nix" "build" "--impure" "--json" "--no-link" "--expr" expr];
       jq = ["|" "${nixpkgs.legacyPackages.${system}.jq}/bin/jq" "-r" "'.[].outputs.out'"];

--- a/src/blocktypes/devshells.nix
+++ b/src/blocktypes/devshells.nix
@@ -44,7 +44,9 @@
             "--builders-use-substitutes"
           )
           nix build "''${nix_args[@]}" --profile "$profile_path/shell-profile"
+          _SHELL="$SHELL"
           eval "$(nix print-dev-env ${developDrv})"
+          SHELL="$_SHELL"
           if ! [[ -v STD_DIRENV ]]; then
             if declare -F __devshell-motd &>/dev/null; then
               __devshell-motd

--- a/src/blocktypes/devshells.nix
+++ b/src/blocktypes/devshells.nix
@@ -14,7 +14,6 @@
     type = "devshells";
     actions = {
       system,
-      flake,
       fragment,
       fragmentRelPath,
       target,
@@ -26,6 +25,10 @@
         name = "enter";
         description = "enter this devshell";
         command = ''
+          if test -z "$PRJ_ROOT"; then
+            echo "PRJ_ROOT is not set. Action aborting."
+            exit 1
+          fi
           std_layout_dir=$PRJ_ROOT/.std
           profile_path="$std_layout_dir/${fragmentRelPath}"
           mkdir -p "$profile_path"

--- a/src/blocktypes/devshells.nix
+++ b/src/blocktypes/devshells.nix
@@ -45,10 +45,10 @@
           )
           nix build "''${nix_args[@]}" --profile "$profile_path/shell-profile"
           eval "$(nix print-dev-env ${developDrv})"
-          if declare -F __devshell-motd &>/dev/null; then
-            __devshell-motd
-          fi
           if ! [[ -v STD_DIRENV ]]; then
+            if declare -F __devshell-motd &>/dev/null; then
+              __devshell-motd
+            fi
             exec $SHELL -i
           fi
         '';

--- a/src/blocktypes/devshells.nix
+++ b/src/blocktypes/devshells.nix
@@ -29,8 +29,11 @@
             echo "PRJ_ROOT is not set. Action aborting."
             exit 1
           fi
-          std_layout_dir=$PRJ_ROOT/.std
-          profile_path="$std_layout_dir/${fragmentRelPath}"
+          if test -z "$PRJ_DATA_DIR"; then
+            echo "PRJ_DATA_DIR is not set. Action aborting."
+            exit 1
+          fi
+          profile_path="$PRJ_DATA_DIR/${fragmentRelPath}"
           mkdir -p "$profile_path"
           # ${developDrv}
           nix_args=(

--- a/src/blocktypes/devshells.nix
+++ b/src/blocktypes/devshells.nix
@@ -18,10 +18,12 @@
       fragmentRelPath,
       target,
     }: [
-      (import ./actions/build.nix flake fragment)
+      (import ./actions/build.nix target)
       {
         name = "enter";
         description = "enter this devshell";
+        # TODO: use target, which will require some additional work because of
+        # https://github.com/NixOS/nix/issues/7468
         command = ''
           std_layout_dir=$PRJ_ROOT/.std
           profile_path="$std_layout_dir/${fragmentRelPath}"

--- a/src/blocktypes/devshells.nix
+++ b/src/blocktypes/devshells.nix
@@ -16,6 +16,7 @@
       flake,
       fragment,
       fragmentRelPath,
+      target,
     }: [
       (import ./actions/build.nix flake fragment)
       {

--- a/src/blocktypes/devshells.nix
+++ b/src/blocktypes/devshells.nix
@@ -31,7 +31,7 @@
           mkdir -p "$profile_path"
           # ${developDrv}
           nix_args=(
-            "${builtins.builtins.unsafeDiscardStringContext developDrv.drvPath}"
+            "${builtins.unsafeDiscardStringContext developDrv.drvPath}"
             "--no-update-lock-file"
             "--no-write-lock-file"
             "--no-warn-dirty"

--- a/src/blocktypes/files.nix
+++ b/src/blocktypes/files.nix
@@ -14,6 +14,7 @@
       flake,
       fragment,
       fragmentRelPath,
+      target,
     }: let
       builder = ["nix" "build" "--impure" "--json" "--no-link" "${flake}#${fragment}"];
       jq = ["|" "${nixpkgs.legacyPackages.${system}.jq}/bin/jq" "-r" "'.[].outputs.out'"];

--- a/src/blocktypes/files.nix
+++ b/src/blocktypes/files.nix
@@ -11,7 +11,6 @@
     type = "files";
     actions = {
       system,
-      flake,
       fragment,
       fragmentRelPath,
       target,

--- a/src/blocktypes/files.nix
+++ b/src/blocktypes/files.nix
@@ -16,14 +16,15 @@
       fragmentRelPath,
       target,
     }: let
-      builder = ["nix" "build" "--impure" "--json" "--no-link" "${flake}#${fragment}"];
-      jq = ["|" "${nixpkgs.legacyPackages.${system}.jq}/bin/jq" "-r" "'.[].outputs.out'"];
-      bat = ["${nixpkgs.legacyPackages.${system}.bat}/bin/bat"];
+      file = toString target;
+      bat = "${nixpkgs.legacyPackages.${system}.bat}/bin/bat";
     in [
       {
         name = "explore";
         description = "interactively explore with bat";
-        command = l.concatStringsSep "\t" (bat ++ ["$("] ++ builder ++ jq ++ [")"]);
+        command = ''
+          ${bat} ${file}
+        '';
       }
     ];
   };

--- a/src/blocktypes/installables.nix
+++ b/src/blocktypes/installables.nix
@@ -22,6 +22,7 @@
       flake,
       fragment,
       fragmentRelPath,
+      target,
     }: [
       (import ./actions/build.nix flake fragment)
       {

--- a/src/blocktypes/installables.nix
+++ b/src/blocktypes/installables.nix
@@ -30,6 +30,7 @@
         name = "install";
         description = "install this target";
         command = ''
+          # ${target}
           nix profile install ${flake}#${fragment}
         '';
       }
@@ -37,6 +38,7 @@
         name = "upgrade";
         description = "upgrade this target";
         command = ''
+          # ${target}
           nix profile upgrade ${flake}#${fragment}
         '';
       }
@@ -44,6 +46,7 @@
         name = "remove";
         description = "remove this target";
         command = ''
+          # ${target}
           nix profile remove ${flake}#${fragment}
         '';
       }
@@ -52,6 +55,7 @@
         name = "bundle";
         description = "bundle this target";
         command = ''
+          # ${target}
           nix bundle --bundler github:Ninlives/relocatable.nix --refresh ${flake}#${fragment}
         '';
       }
@@ -59,6 +63,7 @@
         name = "bundleImage";
         description = "bundle this target to image";
         command = ''
+          # ${target}
           nix bundle --bundler github:NixOS/bundlers#toDockerImage --refresh ${flake}#${fragment}
         '';
       }
@@ -66,6 +71,7 @@
         name = "bundleAppImage";
         description = "bundle this target to AppImage";
         command = ''
+          # ${target}
           nix bundle --bundler github:ralismark/nix-appimage --refresh ${flake}#${fragment}
         '';
       }

--- a/src/blocktypes/installables.nix
+++ b/src/blocktypes/installables.nix
@@ -19,7 +19,6 @@
     type = "installables";
     actions = {
       system,
-      flake,
       fragment,
       fragmentRelPath,
       target,
@@ -31,7 +30,11 @@
         description = "install this target";
         command = ''
           # ${target}
-          nix profile install ${flake}#${fragment}
+          if test -z "$PRJ_ROOT"; then
+            echo "PRJ_ROOT is not set. Action aborting."
+            exit 1
+          fi
+          nix profile install $PRJ_ROOT#${fragment}
         '';
       }
       {
@@ -39,7 +42,11 @@
         description = "upgrade this target";
         command = ''
           # ${target}
-          nix profile upgrade ${flake}#${fragment}
+          if test -z "$PRJ_ROOT"; then
+            echo "PRJ_ROOT is not set. Action aborting."
+            exit 1
+          fi
+          nix profile upgrade $PRJ_ROOT#${fragment}
         '';
       }
       {
@@ -47,7 +54,11 @@
         description = "remove this target";
         command = ''
           # ${target}
-          nix profile remove ${flake}#${fragment}
+          if test -z "$PRJ_ROOT"; then
+            echo "PRJ_ROOT is not set. Action aborting."
+            exit 1
+          fi
+          nix profile remove $PRJ_ROOT#${fragment}
         '';
       }
       # TODO: use target. `nix bundle` requires a flake ref, but we may be able to use nix-bundle instead as a workaround
@@ -56,7 +67,11 @@
         description = "bundle this target";
         command = ''
           # ${target}
-          nix bundle --bundler github:Ninlives/relocatable.nix --refresh ${flake}#${fragment}
+          if test -z "$PRJ_ROOT"; then
+            echo "PRJ_ROOT is not set. Action aborting."
+            exit 1
+          fi
+          nix bundle --bundler github:Ninlives/relocatable.nix --refresh $PRJ_ROOT#${fragment}
         '';
       }
       {
@@ -64,7 +79,11 @@
         description = "bundle this target to image";
         command = ''
           # ${target}
-          nix bundle --bundler github:NixOS/bundlers#toDockerImage --refresh ${flake}#${fragment}
+          if test -z "$PRJ_ROOT"; then
+            echo "PRJ_ROOT is not set. Action aborting."
+            exit 1
+          fi
+          nix bundle --bundler github:NixOS/bundlers#toDockerImage --refresh $PRJ_ROOT#${fragment}
         '';
       }
       {
@@ -72,7 +91,11 @@
         description = "bundle this target to AppImage";
         command = ''
           # ${target}
-          nix bundle --bundler github:ralismark/nix-appimage --refresh ${flake}#${fragment}
+          if test -z "$PRJ_ROOT"; then
+            echo "PRJ_ROOT is not set. Action aborting."
+            exit 1
+          fi
+          nix bundle --bundler github:ralismark/nix-appimage --refresh $PRJ_ROOT#${fragment}
         '';
       }
     ];

--- a/src/blocktypes/installables.nix
+++ b/src/blocktypes/installables.nix
@@ -24,7 +24,8 @@
       fragmentRelPath,
       target,
     }: [
-      (import ./actions/build.nix flake fragment)
+      (import ./actions/build.nix target)
+      # profile commands require a flake ref
       {
         name = "install";
         description = "install this target";
@@ -46,6 +47,7 @@
           nix profile remove ${flake}#${fragment}
         '';
       }
+      # TODO: use target. `nix bundle` requires a flake ref, but we may be able to use nix-bundle instead as a workaround
       {
         name = "bundle";
         description = "bundle this target";

--- a/src/blocktypes/microvms.nix
+++ b/src/blocktypes/microvms.nix
@@ -17,6 +17,7 @@
       flake,
       fragment,
       fragmentRelPath,
+      target,
     }: let
       run = ["nix" "run" "${flake}#${fragment}.config.microvm.runner"];
     in [

--- a/src/blocktypes/microvms.nix
+++ b/src/blocktypes/microvms.nix
@@ -12,7 +12,6 @@
     type = "microvms";
     actions = {
       system,
-      flake,
       fragment,
       fragmentRelPath,
       target,

--- a/src/blocktypes/microvms.nix
+++ b/src/blocktypes/microvms.nix
@@ -19,6 +19,7 @@
       fragmentRelPath,
       target,
     }: let
+      # TODO: convert to using `target`
       run = ["nix" "run" "${flake}#${fragment}.config.microvm.runner"];
     in [
       {

--- a/src/blocktypes/microvms.nix
+++ b/src/blocktypes/microvms.nix
@@ -1,5 +1,5 @@
 {nixpkgs}: let
-  l = nixpkgs.lib // builtins;
+  lib = nixpkgs.lib // builtins;
   /*
   Use the Microvms Blocktype for Microvm.nix - https://github.com/astro/microvm.nix
 
@@ -17,13 +17,9 @@
       fragmentRelPath,
       target,
     }: let
-      run = target':
-      # this is the exact sequence mentioned by the `nix run` docs
-      # and so should be compatible
-        target'.program
-        or "${target'}/bin/${target'.meta.mainProgram
-          or (target'.pname
-            or (l.removeSuffix "-${target.version or ""}" target.name))}";
+      run = import ./actions/run.nix {
+        inherit target lib;
+      };
     in [
       {
         name = "microvm";

--- a/src/blocktypes/microvms.nix
+++ b/src/blocktypes/microvms.nix
@@ -23,7 +23,7 @@
         target'.program
         or "${target'}/bin/${target'.meta.mainProgram
           or (target'.pname
-            or builtins.head (builtins.split "-" target'.name))}";
+            or (l.removeSuffix "-${target.version or ""}" target.name))}";
     in [
       {
         name = "microvm";

--- a/src/blocktypes/nixago.nix
+++ b/src/blocktypes/nixago.nix
@@ -19,7 +19,6 @@
     type = "nixago";
     actions = {
       system,
-      flake,
       fragment,
       fragmentRelPath,
       target,

--- a/src/blocktypes/nixago.nix
+++ b/src/blocktypes/nixago.nix
@@ -28,14 +28,14 @@
         name = "populate";
         description = "populate this nixago file into the repo";
         command = ''
-          nix run ${flake}#${fragment}.install
+          ${target.install}/bin/nixago_shell_hook
         '';
       }
       {
         name = "explore";
         description = "interactively explore the nixago file";
         command = ''
-          ${nixpkgs.legacyPackages.${system}.bat}/bin/bat "$(nix build --no-link --print-out-paths ${flake}#${fragment}.configFile)"
+          ${nixpkgs.legacyPackages.${system}.bat}/bin/bat "${target.configFile}"
         '';
       }
     ];

--- a/src/blocktypes/nixago.nix
+++ b/src/blocktypes/nixago.nix
@@ -22,6 +22,7 @@
       flake,
       fragment,
       fragmentRelPath,
+      target,
     }: [
       {
         name = "populate";

--- a/src/blocktypes/nomadJobManifests.nix
+++ b/src/blocktypes/nomadJobManifests.nix
@@ -24,15 +24,16 @@
       fx = "${nixpkgs.legacyPackages.${system}.fx}/bin";
       nomad = "${nixpkgs.legacyPackages.${system}.nomad}/bin";
       jq = "${nixpkgs.legacyPackages.${system}.jq}/bin";
+      job = baseNameOf fragmentRelPath;
       nixExpr = ''
         x: let
           job = builtins.mapAttrs (_: v: v // {meta = v.meta or {} // {rev = "\"$(git rev-parse --short HEAD)\"";};}) x.job;
         in
-          builtins.toFile \"$job.json\" (builtins.unsafeDiscardStringContext (builtins.toJSON {inherit job;}))
+          builtins.toFile \"${job}.json\" (builtins.unsafeDiscardStringContext (builtins.toJSON {inherit job;}))
       '';
       layout = ''
         std_layout_dir=$PRJ_ROOT/.std
-        job_path="$std_layout_dir/${dirOf fragmentRelPath}/${baseNameOf fragmentRelPath}.json"
+        job_path="$std_layout_dir/${dirOf fragmentRelPath}/${job}.json"
 
         # use Nomad bin in path if it exists, and only fallback on nixpkgs if it doesn't
         PATH="$PATH:${nomad}"

--- a/src/blocktypes/nomadJobManifests.nix
+++ b/src/blocktypes/nomadJobManifests.nix
@@ -35,8 +35,11 @@
           echo "PRJ_ROOT is not set. Action aborting."
           exit 1
         fi
-        std_layout_dir=$PRJ_ROOT/.std
-        job_path="$std_layout_dir/${dirOf fragmentRelPath}/${job}.json"
+        if test -z "$PRJ_DATA_DIR"; then
+          echo "PRJ_DATA_DIR is not set. Action aborting."
+          exit 1
+        fi
+        job_path="$PRJ_DATA_DIR/${dirOf fragmentRelPath}/${job}.json"
 
         # use Nomad bin in path if it exists, and only fallback on nixpkgs if it doesn't
         PATH="$PATH:${nomad}"

--- a/src/blocktypes/nomadJobManifests.nix
+++ b/src/blocktypes/nomadJobManifests.nix
@@ -19,6 +19,7 @@
       flake,
       fragment,
       fragmentRelPath,
+      target,
     }: let
       fx = "${nixpkgs.legacyPackages.${system}.fx}/bin";
       nomad = "${nixpkgs.legacyPackages.${system}.nomad}/bin";

--- a/src/blocktypes/runnables.nix
+++ b/src/blocktypes/runnables.nix
@@ -10,7 +10,6 @@
     type = "runnables";
     actions = {
       system,
-      flake,
       fragment,
       fragmentRelPath,
       target,

--- a/src/blocktypes/runnables.nix
+++ b/src/blocktypes/runnables.nix
@@ -26,7 +26,7 @@
             target.program
             or "${target}/bin/${target.meta.mainProgram
               or (target.pname
-                or builtins.head (builtins.split "-" target.name))}";
+                or (l.removeSuffix "-${target.version or ""}" target.name))}";
         in
           run;
       }

--- a/src/blocktypes/runnables.nix
+++ b/src/blocktypes/runnables.nix
@@ -25,8 +25,8 @@
             # and so should be compatible
             target.program
             or "${target}/bin/${target.meta.mainProgram
-              or target.pname
-              or builtins.head (builtins.split "-" target.name)}";
+              or (target.pname
+                or builtins.head (builtins.split "-" target.name))}";
         in
           run;
       }

--- a/src/blocktypes/runnables.nix
+++ b/src/blocktypes/runnables.nix
@@ -15,13 +15,20 @@
       fragmentRelPath,
       target,
     }: [
-      (import ./actions/build.nix flake fragment)
+      (import ./actions/build.nix target)
       {
         name = "run";
         description = "exec this target";
-        command = ''
-          nix run ${flake}#${fragment} -- "$@"
-        '';
+        command = let
+          run =
+            # this is the exact sequence mentioned by the `nix run` docs
+            # and so should be compatible
+            target.program
+            or "${target}/bin/${target.meta.mainProgram
+              or target.pname
+              or builtins.head (builtins.split "-" target.name)}";
+        in
+          run;
       }
     ];
   };

--- a/src/blocktypes/runnables.nix
+++ b/src/blocktypes/runnables.nix
@@ -1,5 +1,5 @@
 {nixpkgs}: let
-  l = nixpkgs.lib // builtins;
+  lib = nixpkgs.lib // builtins;
   /*
   Use the Runnables Blocktype for targets that you want to
   make accessible with a 'run' action on the TUI.
@@ -19,16 +19,9 @@
       {
         name = "run";
         description = "exec this target";
-        command = let
-          run =
-            # this is the exact sequence mentioned by the `nix run` docs
-            # and so should be compatible
-            target.program
-            or "${target}/bin/${target.meta.mainProgram
-              or (target.pname
-                or (l.removeSuffix "-${target.version or ""}" target.name))}";
-        in
-          run;
+        command = import ./actions/run.nix {
+          inherit target lib;
+        };
       }
     ];
   };

--- a/src/blocktypes/runnables.nix
+++ b/src/blocktypes/runnables.nix
@@ -13,6 +13,7 @@
       flake,
       fragment,
       fragmentRelPath,
+      target,
     }: [
       (import ./actions/build.nix flake fragment)
       {

--- a/src/devshell-drv.nix
+++ b/src/devshell-drv.nix
@@ -1,0 +1,151 @@
+# remove once upstream nixpkgs includes the `developDerivation`
+# https://github.com/NixOS/nixpkgs/pull/206915
+drv: let
+  inherit (drv) drvAttrs;
+  getEnv = builtins.toFile "get-env.sh" ''
+
+    set -e
+    if [ -e .attrs.sh ]; then source .attrs.sh; fi
+
+    export IN_NIX_SHELL=impure
+    export dontAddDisableDepTrack=1
+
+    if [[ -n $stdenv ]]; then
+        source $stdenv/setup
+    fi
+
+    # Better to use compgen, but stdenv bash doesn't have it.
+    __vars="$(declare -p)"
+    __functions="$(declare -F)"
+
+    __dumpEnv() {
+        printf '{\n'
+
+        printf '  "bashFunctions": {\n'
+        local __first=1
+        while read __line; do
+            if ! [[ $__line =~ ^declare\ -f\ (.*) ]]; then continue; fi
+            __fun_name="''${BASH_REMATCH[1]}"
+            __fun_body="$(type $__fun_name)"
+            if [[ $__fun_body =~ \{(.*)\} ]]; then
+                if [[ -z $__first ]]; then printf ',\n'; else __first=; fi
+                __fun_body="''${BASH_REMATCH[1]}"
+                printf "    "
+                __escapeString "$__fun_name"
+                printf ':'
+                __escapeString "$__fun_body"
+            else
+                printf "Cannot parse definition of function '%s'.\n" "$__fun_name" >&2
+                return 1
+            fi
+        done < <(printf "%s\n" "$__functions")
+        printf '\n  },\n'
+
+        printf '  "variables": {\n'
+        local __first=1
+        while read __line; do
+            if ! [[ $__line =~ ^declare\ (-[^ ])\ ([^=]*) ]]; then continue; fi
+            local type="''${BASH_REMATCH[1]}"
+            local __var_name="''${BASH_REMATCH[2]}"
+
+            if [[ $__var_name =~ ^BASH_ || \
+                  $__var_name =~ ^COMP_ || \
+                  $__var_name = _ || \
+                  $__var_name = DIRSTACK || \
+                  $__var_name = EUID || \
+                  $__var_name = FUNCNAME || \
+                  $__var_name = HISTCMD || \
+                  $__var_name = HOSTNAME || \
+                  $__var_name = GROUPS || \
+                  $__var_name = PIPESTATUS || \
+                  $__var_name = PWD || \
+                  $__var_name = RANDOM || \
+                  $__var_name = SHLVL || \
+                  $__var_name = SECONDS || \
+                  $__var_name = EPOCHREALTIME || \
+                  $__var_name = EPOCHSECONDS \
+                ]]; then continue; fi
+
+            if [[ -z $__first ]]; then printf ',\n'; else __first=; fi
+
+            printf "    "
+            __escapeString "$__var_name"
+            printf ': {'
+
+            # FIXME: handle -i, -r, -n.
+            if [[ $type == -x ]]; then
+                printf '"type": "exported", "value": '
+                __escapeString "''${!__var_name}"
+            elif [[ $type == -- ]]; then
+                printf '"type": "var", "value": '
+                __escapeString "''${!__var_name}"
+            elif [[ $type == -a ]]; then
+                printf '"type": "array", "value": ['
+                local __first2=1
+                __var_name="$__var_name[@]"
+                for __i in "''${!__var_name}"; do
+                    if [[ -z $__first2 ]]; then printf ', '; else __first2=; fi
+                    __escapeString "$__i"
+                    printf ' '
+                done
+                printf ']'
+            elif [[ $type == -A ]]; then
+                printf '"type": "associative", "value": {\n'
+                local __first2=1
+                declare -n __var_name2="$__var_name"
+                for __i in "''${!__var_name2[@]}"; do
+                    if [[ -z $__first2 ]]; then printf ',\n'; else __first2=; fi
+                    printf "      "
+                    __escapeString "$__i"
+                    printf ": "
+                    __escapeString "''${__var_name2[$__i]}"
+                done
+                printf '\n    }'
+            else
+                printf '"type": "unknown"'
+            fi
+
+            printf "}"
+        done < <(printf "%s\n" "$__vars")
+        printf '\n  }\n}'
+    }
+
+    __escapeString() {
+        local __s="$1"
+        __s="''${__s//\\/\\\\}"
+        __s="''${__s//\"/\\\"}"
+        __s="''${__s//$'\n'/\\n}"
+        __s="''${__s//$'\r'/\\r}"
+        __s="''${__s//$'\t'/\\t}"
+        printf '"%s"' "$__s"
+    }
+
+    # In case of `__structuredAttrs = true;` the list of outputs is an associative
+    # array with a format like `outname => /nix/store/hash-drvname-outname`, so `__olist`
+    # must contain the array's keys (hence `''${!...[@]}`) in this case.
+    if [ -e .attrs.sh ]; then
+        __olist="''${!outputs[@]}"
+    else
+        __olist=$outputs
+    fi
+
+    for __output in $__olist; do
+        if [[ -z $__done ]]; then
+            __dumpEnv > ''${!__output}
+            __done=1
+        else
+            echo -n >> "''${!__output}"
+        fi
+    done
+  '';
+
+  argContext = builtins.getContext (toString drvAttrs.args);
+
+  env =
+    drvAttrs
+    // {
+      name = "${drvAttrs.name}-env";
+      args = [(builtins.appendContext getEnv argContext)];
+    };
+in
+  derivation env

--- a/src/grow.nix
+++ b/src/grow.nix
@@ -214,12 +214,31 @@
             actions =
               if cellBlock ? actions
               then
-                cellBlock.actions {
-                  inherit system;
-                  fragment = targetFragment;
-                  fragmentRelPath = "${cellName}/${cellBlock.name}/${name}";
-                  target = res.output.${cellBlock.name}.${name};
-                }
+                (
+                  if
+                    l.trivial.functionArgs
+                    == {
+                      system = false;
+                      flake = false;
+                      fragment = false;
+                      fragmentRelPath = false;
+                    }
+                  then
+                    # warnOldActionInterface
+                    cellBlock.actions {
+                      inherit system;
+                      flake = inputs.self.sourceInfo.outPath;
+                      fragment = targetFragment;
+                      fragmentRelPath = "${cellName}/${cellBlock.name}/${name}";
+                    }
+                  else
+                    cellBlock.actions {
+                      inherit system;
+                      fragment = targetFragment;
+                      fragmentRelPath = "${cellName}/${cellBlock.name}/${name}";
+                      target = res.output.${cellBlock.name}.${name};
+                    }
+                )
               else [];
             ci =
               if cellBlock ? ci

--- a/src/grow.nix
+++ b/src/grow.nix
@@ -216,7 +216,6 @@
               then
                 cellBlock.actions {
                   inherit system;
-                  flake = inputs.self.sourceInfo.outPath;
                   fragment = targetFragment;
                   fragmentRelPath = "${cellName}/${cellBlock.name}/${name}";
                   target = res.output.${cellBlock.name}.${name};

--- a/src/grow.nix
+++ b/src/grow.nix
@@ -219,6 +219,7 @@
                   flake = inputs.self.sourceInfo.outPath;
                   fragment = targetFragment;
                   fragmentRelPath = "${cellName}/${cellBlock.name}/${name}";
+                  target = res.output.${cellBlock.name}.${name};
                 }
               else [];
             ci =

--- a/src/grow.nix
+++ b/src/grow.nix
@@ -248,7 +248,6 @@
               f = set:
                 set
                 // {
-                  targetDrv = inputs.self.${system}.${set.cell}.${set.block}.${set.name}.drvPath or null;
                   actionDrv = inputs.self.__std.actions.${system}.${set.cell}.${set.block}.${set.name}.${set.action}.drvPath or null;
                 };
             in

--- a/src/validators.nix
+++ b/src/validators.nix
@@ -72,15 +72,45 @@ in {
       type = string;
       __functor = option function;
       ci = option (attrs bool);
-      actions = option (functionWithArgs {
-        system = false;
-        fragment = false;
-        fragmentRelPath = false;
-        target = false;
+      actions = option (
+        functionWithArgs {
+          system = false;
+          target = false;
+          fragment = false;
+          fragmentRelPath = false;
+        }
+      );
+    };
+    # warnOldActionInterface
+    cellBlockOldActionInterface = struct "cellBlockOldActionInterface" {
+      name = string;
+      type = string;
+      __functor = option function;
+      ci = option (attrs bool);
+      actions = option (let
+        type = functionWithArgs {
+          system = false;
+          flake = false;
+          fragment = false;
+          fragmentRelPath = false;
+        };
+      in {
+        inherit (type) name logContext checkToBool toError check;
+        checkType = x:
+          (
+            import ../deprecation.nix {inherit nixpkgs;}
+          )
+          .warnOldActionInterface (x {
+            flake = "";
+            fragment = [];
+            system = "";
+            fragmentRelPath = "";
+          }) (type.checkType x);
+        __functor = self: type.__functor self;
       });
     };
   in
-    list cellBlock;
+    list (either cellBlock cellBlockOldActionInterface);
   BlockSignature = file: block: let
     file' = prefixWithCellsFrom file;
   in

--- a/src/validators.nix
+++ b/src/validators.nix
@@ -74,7 +74,6 @@ in {
       ci = option (attrs bool);
       actions = option (functionWithArgs {
         system = false;
-        flake = false;
         fragment = false;
         fragmentRelPath = false;
         target = false;

--- a/src/validators.nix
+++ b/src/validators.nix
@@ -77,6 +77,7 @@ in {
         flake = false;
         fragment = false;
         fragmentRelPath = false;
+        target = false;
       });
     };
   in


### PR DESCRIPTION
This will allow us to properly capture build dependencies for the action, allowing `divnix/std-action` to build them in the proper phase, also ensuring they get cached. This also fixes #203, where the calling `nix` on `self` strips the flake of its git information, making `self.rev` inaccessible.

Alternative to #202 which satisfies divnix/std-action#23

Already tested and working for the publish action, just need to finish converting the rest of the actions to this interface before moving out of draft.