### PR TITLE
fix: remove run action for microvm

### DIFF
--- a/src/blocktypes/microvms.nix
+++ b/src/blocktypes/microvms.nix
@@ -27,7 +27,7 @@
         name = "microvm";
         description = "exec this microvm";
         command = ''
-          ${run target.config.microvm.runner.${target.config.microvm.hypervisor}}
+          ${target.config.microvm.runner.${target.config.microvm.hypervisor}}
         '';
       })
     ];


### PR DESCRIPTION
The microvm doesn't need the run action.

![1:2:bash -  NixOS   2022-12-23 14-02-20](https://user-images.githubusercontent.com/21156405/209409157-e8246f6c-c6cd-4a5a-9ee4-1c848dc3fcdf.jpg)
