### PR TITLE
fix: violently nudge the use of an up-to-date nix version

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -7,18 +7,16 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: cachix/install-nix-action@v17
+      - uses: nixbuild/nix-quick-install-action@v21
         with:
-          install_url: https://github.com/numtide/nix-unstable-installer/releases/download/nix-2.9.0pre20220519_5aeda91/install
-          extra_nix_config: |
+          nix_conf: |
             experimental-features = nix-command flakes
-            system-features = nixos-test benchmark big-parallel kvm recursive-nix
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - run: nix develop .#book -c mdbook build

--- a/.github/workflows/nix-darwin.yaml
+++ b/.github/workflows/nix-darwin.yaml
@@ -4,14 +4,16 @@ on:
   pull_request:
 
 jobs:
-  build:
+  check:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v17
+
+      - uses: nixbuild/nix-quick-install-action@v21
         with:
-          skip_adding_nixpkgs_channel: true
-          extra_nix_config: |
+          nix_version: 2.9.2
+          nix_conf: |
+            experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - name: Nix Flake Show

--- a/.github/workflows/nix-linux.yaml
+++ b/.github/workflows/nix-linux.yaml
@@ -6,14 +6,13 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.0.2
+      - uses: actions/checkout@v3
 
-      - uses: cachix/install-nix-action@v17
+      - uses: nixbuild/nix-quick-install-action@v21
         with:
-          install_url: https://github.com/numtide/nix-unstable-installer/releases/download/nix-2.9.0pre20220519_5aeda91/install
-          extra_nix_config: |
+          nix_version: 2.9.2
+          nix_conf: |
             experimental-features = nix-command flakes
-            system-features = nixos-test benchmark big-parallel kvm recursive-nix
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - name: Nix Flake Show

--- a/src/grow.nix
+++ b/src/grow.nix
@@ -406,28 +406,29 @@
       ];
     res = accumulate (l.map loadOutputFor Systems);
   in
-    res.output
-    // {
-      __std.__schema = "v0";
-      __std.ci = l.listToAttrs res.ci;
-      __std.ci' = l.listToAttrs res.ci';
-      __std.init = l.listToAttrs res.init;
-      __std.actions = res.actions;
-      __std.direnv_lib = ../direnv_lib.sh;
-      __std.nixConfig = let
-        # FIXME: refactor when merged NixOS/nixpkgs#203999
-        nixConfig = l.generators.toKeyValue {
-          mkKeyValue = l.generators.mkKeyValueDefault {
-            mkValueString = v:
-              if l.isList v
-              then l.concatStringsSep " " v
-              else if (l.isPath v || v ? __toString)
-              then toString v
-              else l.generators.mkValueStringDefault {} v;
-          } " = ";
-        };
-      in
-        nixConfig (import "${inputs.self}/flake.nix").nixConfig or {};
-    };
+    assert l.assertMsg ((l.compareVersions l.nixVersion "2.9.2") >= 0) "Go back to square one: you'll need a newer nix version (minimum: v2.9.2).";
+      res.output
+      // {
+        __std.__schema = "v0";
+        __std.ci = l.listToAttrs res.ci;
+        __std.ci' = l.listToAttrs res.ci';
+        __std.init = l.listToAttrs res.init;
+        __std.actions = res.actions;
+        __std.direnv_lib = ../direnv_lib.sh;
+        __std.nixConfig = let
+          # FIXME: refactor when merged NixOS/nixpkgs#203999
+          nixConfig = l.generators.toKeyValue {
+            mkKeyValue = l.generators.mkKeyValueDefault {
+              mkValueString = v:
+                if l.isList v
+                then l.concatStringsSep " " v
+                else if (l.isPath v || v ? __toString)
+                then toString v
+                else l.generators.mkValueStringDefault {} v;
+            } " = ";
+          };
+        in
+          nixConfig (import "${inputs.self}/flake.nix").nixConfig or {};
+      };
 in
   grow


### PR DESCRIPTION
it's a fast-paced world now-a-days...


We had a user that hit an unbound feedback loop strolling into an UX abyss on `nix 2.5`...

- 2.7 has `.default` over `defaultX` semantics
- 2.9, iirc, has the vital `__funtor` fix