### PR TITLE
fix: pass args to runnables

### DIFF
--- a/src/blocktypes/actions/run.nix
+++ b/src/blocktypes/actions/run.nix
@@ -12,6 +12,6 @@
     # this is the exact sequence mentioned by the `nix run` docs
     # and so should be compatible
     target.program
-    or "${target}/bin/${programName}";
+      or "${target}/bin/${programName} \"$@\"";
 in
   run


### PR DESCRIPTION

```
λ std //cliche/entrypoints/example:run add 1 2
3
```