### PR TITLE
fix: make build proviso much more robust

### DIFF
--- a/src/actions.nix
+++ b/src/actions.nix
@@ -24,16 +24,13 @@
             local -a uncached
 
             # FIXME: merge upstream to avoid any need for runtime context
-            command nix build github:divnix/nix-uncached/v2.12.1
+            command nix build github:divnix/nix-uncached/v2.13.1
 
-            drvs="$(command jq -r '.targetDrv | select(. != "null")' <<< "''${input[@]}")"
+            drvs=$(command jq -r '.targetDrv | select(. != "null")' <<< "''${input[@]}")
 
-            mapfile -t uncached < <(command nix show-derivation $drvs | jq -r '.[].outputs.out.path' | result/bin/nix-uncached)
+            uncached_json=$(result/bin/nix-uncached $drvs)
 
-            if [[ -n ''${uncached[*]} ]]; then
-              mapfile -t uncached < <(command nix show-derivation ''${uncached[@]} \
-              | command jq -r '.| to_entries[] | select(.value|.env.preferLocalBuild != "1") | .key')
-            fi
+            mapfile -t uncached < <(command jq -r 'to_entries[]|select(.value == [])|.key' <<< "$uncached_json")
 
             if [[ -n ''${uncached[*]} ]]; then
               local list filtered


### PR DESCRIPTION
The latest nix-uncached provides a more efficient schema which allows us to make a single call and still query the entire dependency closure for each path passed.

This will now capture any uncached dependencies even for derivations which are typically built locally, such as a NixOS system.

Also includes a nice speedup thanks to async queries _a la_ divnix/nix-uncached#1

We may also stand a better chance of getting an implementation like this merged upstream:
https://github.com/NixOS/nix/pull/7587#issuecomment-1399970497