### PR TITLE
keep writeScrips' shOpts same as nixpkgs.writeShellApplcaion

### DIFF
--- a/cells/lib/ops/writeScript.nix
+++ b/cells/lib/ops/writeScript.nix
@@ -29,12 +29,6 @@ in
           set -o errexit
           set -o pipefail
           set -o nounset
-          set -o functrace
-          set -o errtrace
-          set -o monitor
-          set -o posix
-          shopt -s dotglob
-
         ''
         + l.optionalString (runtimeInputs != []) ''
           export PATH="${l.makeBinPath runtimeInputs}:$PATH"


### PR DESCRIPTION
@jmgilman 
We should use a minimal shOpts setting to prevent other tools from causing unnecessary trouble when calling bash scripts.

Perhaps we can add an option to turn off the additional shOpts.
