### PR TITLE
feat: polish the mkOCI interface further by exposing oft-used 'config'

### DIFF
--- a/cells/lib/ops/mkOCI.nix
+++ b/cells/lib/ops/mkOCI.nix
@@ -19,6 +19,7 @@ in
   perms: A list of permissions to set for the container.
   labels: An attribute set of labels to set for the container. The keys are
   automatically prefixed with "org.opencontainers.image".
+  config: Additional options to pass to nix2container.buildImage's config.
   options: Additional options to pass to nix2container.buildImage.
 
   Returns:
@@ -35,13 +36,14 @@ in
     gid ? "65534",
     perms ? [],
     labels ? {},
+    config ? {},
     options ? {},
   }: let
     setupLinks = cell.ops.mkSetup "links" [] ''
       mkdir -p $out/bin
       ln -s ${l.getExe entrypoint} $out/bin/entrypoint
     '';
-    config =
+    options' =
       {
         inherit name;
 
@@ -66,16 +68,18 @@ in
         maxLayers = 25;
         copyToRoot = [setupLinks] ++ setup;
 
-        config = {
-          User = uid;
-          Group = gid;
-          Entrypoint = ["/bin/entrypoint"];
-          Labels = l.mapAttrs' (n: v: l.nameValuePair "org.opencontainers.image.${n}" v) labels;
-        };
+        config =
+          l.recursiveUpdate {
+            User = uid;
+            Group = gid;
+            Entrypoint = ["/bin/entrypoint"];
+            Labels = l.mapAttrs' (n: v: l.nameValuePair "org.opencontainers.image.${n}" v) labels;
+          }
+          config;
 
         # Setup tasks can include permissions via the passthru.perms attribute
         perms = l.flatten ((l.map (s: l.optionalAttrs (s ? passthru && s.passthru ? perms) s.passthru.perms)) setup) ++ perms;
       }
       // l.optionalAttrs (tag != "") {inherit tag;};
   in
-    n2c.buildImage (l.recursiveUpdate config options)
+    n2c.buildImage (l.recursiveUpdate options' options)

--- a/cells/lib/ops/mkStandardOCI.nix
+++ b/cells/lib/ops/mkStandardOCI.nix
@@ -20,6 +20,7 @@ in
   labels: An attribute set of labels to set for the container. The keys are
   automatically prefixed with "org.opencontainers.image".
   debug: Whether to include debug tools in the container (coreutils).
+  config: Additional options to pass to nix2container.buildImage's config.
   options: Additional options to pass to nix2container.
 
   Returns:
@@ -35,6 +36,7 @@ in
     perms ? [],
     labels ? {},
     debug ? false,
+    config ? {},
     options ? {},
   }: let
     # Link useful paths into the container.
@@ -67,7 +69,7 @@ in
     '';
   in
     cell.ops.mkOCI {
-      inherit name tag uid gid labels options perms;
+      inherit name tag uid gid labels options perms config;
       entrypoint = operable';
       setup = [setupLinks] ++ setup;
       runtimeInputs = operable.passthru.runtimeInputs;


### PR DESCRIPTION
When images need more configuration than the default exposed options,
in most cases, it is concerned with n2c's 'config' iface.

To honor that reality, let's expose it.

While this adds two similar interfaces (options & config), in practice,
when people copy over examples they would only see:

```nix
{
  config = /* snip */;
}
```

That is less confusing than the following.
This was also the semantic hickup that prompted this commit:
```nix
{
  options.config = /* snip */;
}
```
