### PR TITLE
feat: allow flakeModule usage without growing anything

### DIFF
--- a/src/flakeModule.nix
+++ b/src/flakeModule.nix
@@ -166,13 +166,14 @@ in {
       picked = mapAttrs (_: v: pick grown v) cfg.pick;
       harvested = mapAttrs (_: v: harvest grown v) cfg.harvest;
       winnowed = zipAttrsWith (n: v: winnow (head v) grown (head (tail v))) [cfg.winnowIf cfg.winnow];
-    in
+    in lib.mkIf (opt.grow.isDefined) (
       lib.foldl' lib.recursiveUpdate {} (
         [grown]
         ++ (lib.optionals opt.pick.isDefined [picked])
         ++ (lib.optionals (opt.winnow.isDefined && opt.winnowIf.isDefined) [winnowed])
         ++ (lib.optionals opt.harvest.isDefined [harvested])
-      );
+      )
+    );
 
     # exposes the raw scheme of the std layout inside flake-parts
     perInput = system: flake: {cells = flake.${system} or {};};


### PR DESCRIPTION
This allows the module to be used in a situation where the caller consumes `inputs'.foo.cells` but does not use the std options to define its own outputs.