### PR TITLE
feat: acquire ownership over container actions from n2c

### DIFF
--- a/cells/lib/ops/mkOCI.nix
+++ b/cells/lib/ops/mkOCI.nix
@@ -46,7 +46,7 @@ in
     '';
     options' =
       {
-        inherit name;
+        inherit name meta;
 
         # Layers are nested to reduce duplicate paths in the image
         layers =
@@ -83,6 +83,4 @@ in
       }
       // l.optionalAttrs (tag != "") {inherit tag;};
   in
-    (n2c.buildImage (l.recursiveUpdate options' options)).overrideAttrs (prev: {
-      meta = (prev.meta or {}) // meta;
-    })
+    n2c.buildImage (l.recursiveUpdate options' options)

--- a/cells/lib/ops/mkOCI.nix
+++ b/cells/lib/ops/mkOCI.nix
@@ -38,6 +38,7 @@ in
     labels ? {},
     config ? {},
     options ? {},
+    meta ? {},
   }: let
     setupLinks = cell.ops.mkSetup "links" [] ''
       mkdir -p $out/bin
@@ -82,4 +83,6 @@ in
       }
       // l.optionalAttrs (tag != "") {inherit tag;};
   in
-    n2c.buildImage (l.recursiveUpdate options' options)
+    (n2c.buildImage (l.recursiveUpdate options' options)).overrideAttrs (prev: {
+      meta = (prev.meta or {}) // meta;
+    })

--- a/cells/lib/ops/mkStandardOCI.nix
+++ b/cells/lib/ops/mkStandardOCI.nix
@@ -38,6 +38,7 @@ in
     debug ? false,
     config ? {},
     options ? {},
+    meta ? {},
   }: let
     # Link useful paths into the container.
     runtimeEntryLink = "ln -s ${l.getExe operable.passthru.runtime} $out/bin/runtime";
@@ -69,7 +70,7 @@ in
     '';
   in
     cell.ops.mkOCI {
-      inherit name tag uid gid labels options perms config;
+      inherit name tag uid gid labels options perms config meta;
       entrypoint = operable';
       setup = [setupLinks] ++ setup;
       runtimeInputs = operable.passthru.runtimeInputs;

--- a/flake.lock
+++ b/flake.lock
@@ -106,11 +106,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665039323,
-        "narHash": "sha256-SAh3ZjFGsaCI8FRzXQyp56qcGdAqgKEfJWPCQ0Sr7tQ=",
+        "lastModified": 1677330646,
+        "narHash": "sha256-hUYCwJneMjnxTvj30Fjow6UMJUITqHlpUGpXMPXUJsU=",
         "owner": "nlewo",
         "repo": "nix2container",
-        "rev": "b008fe329ffb59b67bf9e7b08ede6ee792f2741a",
+        "rev": "ebca8f58d450cae1a19c07701a5a8ae40afc9efc",
         "type": "github"
       },
       "original": {
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677298389,
-        "narHash": "sha256-gNOsmmr3HiNXFaQ+Rc4USFoKksS+6KKZpCTThnnwW6Q=",
+        "lastModified": 1677437285,
+        "narHash": "sha256-YGfMothgUq1T9wMJYEhOSvdIiD/8gLXO1YcZA6hyIWU=",
         "owner": "paisano-nix",
         "repo": "core",
-        "rev": "687683ae1d9028135a43ed1f9cc3954cf55fc689",
+        "rev": "5f2fc05e98e001cb1cf9535ded09e05d90cec131",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
         "std": []
       },
       "locked": {
-        "lastModified": 1677306024,
-        "narHash": "sha256-zMiBGCFZtefvlnmXNyG9+ofYLj/xNpKfXEJJHwOGbpE=",
+        "lastModified": 1677366563,
+        "narHash": "sha256-c4a9Qd2xXO8zxMTuJQWmDrdIbmwlGjKcOyjB1xnRHjQ=",
         "owner": "paisano-nix",
         "repo": "tui",
-        "rev": "0fe88586963807b918cab3e4a6a651604b0a82c2",
+        "rev": "f45d054b1329e70e475eb185367d18fa08a6a176",
         "type": "github"
       },
       "original": {
@@ -252,11 +252,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677285314,
-        "narHash": "sha256-hlAcg2514zKrPu8jn24BUsIjjvXvCLdw1jvKgBTpqko=",
+        "lastModified": 1667096281,
+        "narHash": "sha256-wRRec6ze0gJHmGn6m57/zhz/Kdvp9HS4Nl5fkQ+uIuA=",
         "owner": "divnix",
         "repo": "yants",
-        "rev": "9eab24b273ce021406c852166c216b86e2bb4ec4",
+        "rev": "d18f356ec25cb94dc9c275870c3a7927a10f8c3c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
       __std_data_wrapper = true;
       inherit data meta;
     };
-    blockTypes = import ./src/blocktypes.nix {inherit (inputs) nixpkgs;};
+    blockTypes = import ./src/blocktypes.nix {inherit (inputs) nixpkgs n2c;};
     sharedActions = import ./src/actions.nix {inherit (inputs) nixpkgs;};
     l = inputs.nixpkgs.lib // builtins;
 

--- a/src/blocktypes.nix
+++ b/src/blocktypes.nix
@@ -1,4 +1,7 @@
-{nixpkgs}: let
+{
+  nixpkgs,
+  n2c, # nix2container
+}: let
   sharedActions = import ./actions.nix {inherit nixpkgs;};
   mkCommand = import ./mkCommand.nix {inherit nixpkgs;};
 in {
@@ -8,7 +11,7 @@ in {
   anything = import ./blocktypes/anything.nix {inherit nixpkgs mkCommand;};
   data = import ./blocktypes/data.nix {inherit nixpkgs mkCommand;};
   devshells = import ./blocktypes/devshells.nix {inherit nixpkgs mkCommand sharedActions;};
-  containers = import ./blocktypes/containers.nix {inherit nixpkgs mkCommand sharedActions;};
+  containers = import ./blocktypes/containers.nix {inherit n2c nixpkgs mkCommand sharedActions;};
   files = import ./blocktypes/files.nix {inherit nixpkgs mkCommand;};
   microvms = import ./blocktypes/microvms.nix {inherit nixpkgs mkCommand;};
   nixago = import ./blocktypes/nixago.nix {inherit nixpkgs mkCommand;};

--- a/src/blocktypes/containers.nix
+++ b/src/blocktypes/containers.nix
@@ -10,9 +10,8 @@
 
   Available actions:
     - print-image
-    - copy-to-registry
-    - copy-to-podman
-    - copy-to-docker
+    - publish
+    - load
   */
   containers = name: {
     __functor = import ./__functor.nix;
@@ -26,32 +25,28 @@
     }: let
       inherit (n2c.packages.${currentSystem}) skopeo-nix2container;
       img = builtins.unsafeDiscardStringContext target.imageName;
-      tags = let
-        tags' = target.meta.tags or [(builtins.unsafeDiscardStringContext target.imageTag)];
-      in
-        builtins.toFile "${target.name}-tags.json" (builtins.unsafeDiscardStringContext (builtins.concatStringsSep "\n" tags'));
-      copyTags = let
+      tags = target.meta.tags or [(builtins.unsafeDiscardStringContext target.imageTag)];
+      tags' =
+        builtins.toFile "${target.name}-tags.json" (builtins.unsafeDiscardStringContext (builtins.concatStringsSep "\n" tags));
+      copyFn = let
         skopeo = "skopeo --insecure-policy";
       in ''
         export PATH=${skopeo-nix2container}/bin:$PATH
 
-        copy_tags() {
-          local name tags source img
-          source=nix:${target}
-          tags=${tags}
-          name=$1
+        copy() {
+          local uri prev_tag
+          uri=$1
           shift
 
-          for tag in $(<$tags); do
-            img="$name:$tag"
-            if ! [[ -v prev_img ]]; then
-              ${skopeo} copy $source "$img" "$@"
+          for tag in $(<${tags'}); do
+            if ! [[ -v prev_tag ]]; then
+              ${skopeo} copy nix:${target} "$uri:tag" "$@"
             else
               # speedup: copy from the previous tag to avoid superflous network bandwidth
-              ${skopeo} copy "$prev_img" "$img" "$@"
+              ${skopeo} copy "$uri:$prev_tag" "$uri:tag" "$@"
             fi
 
-            prev_img="$img"
+            prev_tag="$tag"
           done
         }
       '';
@@ -59,81 +54,39 @@
       (sharedActions.build currentSystem target)
       (mkCommand currentSystem {
         name = "print-image";
-        description = "print out the image name & tag";
+        description = "print out the image name with all tags";
         command = ''
           echo
-          echo "${target.imageName}:${target.imageTag}"
+          for tag in $(<${tags'}); do
+            echo "${img}:$tag"
+          done
         '';
       })
       (mkCommand currentSystem {
         name = "publish";
         description = "copy the image to its remote registry";
         command = ''
-          ${copyTags}
-
-          copy_tags docker://${img}
+          ${copyFn}
+          copy docker://${img}
         '';
-        proviso =
-          l.toFile "container-proviso"
-          # bash
-          ''
-            function proviso() {
-            local -n input=$1
-            local -n output=$2
-
-            local -a images
-            local delim="$RANDOM"
-
-            function get_images () {
-              command nix show-derivation $@ \
-              | command jq -r '.[].env.__provisory'
-            }
-
-            drvs="$(command jq -r '.actionDrv | select(. != "null")' <<< "''${input[@]}")"
-
-            mapfile -t images < <(get_images $drvs)
-
-            command cat << "$delim" > /tmp/check.sh
-            #!/usr/bin/env bash
-            if ! command skopeo inspect --insecure-policy "$1" &>/dev/null; then
-            echo "$1" >> /tmp/no_exist
-            fi
-            $delim
-
-            chmod +x /tmp/check.sh
-
-            rm -f /tmp/no_exist
-
-            echo "''${images[@]}" \
-            | command xargs -n 1 -P 0 /tmp/check.sh
-
-            declare -a filtered
-
-            for i in "''${!images[@]}"; do
-              if command grep "''${images[$i]}" /tmp/no_exist &>/dev/null; then
-                filtered+=("''${input[$i]}")
-              fi
-            done
-
-            output=$(command jq -cs '. += $p' --argjson p "$output" <<< "''${filtered[@]}")
-            }
-          '';
-
-        provisory = target.meta.provisory or "${img}:${target.imageTag}";
+        proviso = l.toFile "container-proviso" ''
+          SKOPEO_INSPECT=${./proviso/skopeo-inspect.sh}
+          ${builtins.readFile ./proviso/publish.sh}
+        '';
+        meta.images = map (tag: "${img}:${tag}") tags;
       })
       (mkCommand currentSystem {
         name = "load";
         description = "load image to the local docker daemon";
         command = ''
-          ${copyTags}
-
+          ${copyFn}
           if command -v podman &> /dev/null; then
-             ixecontainerho "Podman detected: copy to local podman"
-             copy_tags containers-storage:${img} "$@"
+             echo "Podman detected: copy to local podman"
+             copy containers-storage:${img} "$@"
           fi
           if command -v docker &> /dev/null; then
              echo "Docker detected: copy to local docker"
-             copy_tags docker-daemon:${img} "$@"
+             copy docker-daemon:${img} "$@"
           fi
         '';
       })

--- a/src/blocktypes/proviso/publish.sh
+++ b/src/blocktypes/proviso/publish.sh
@@ -1,0 +1,29 @@
+SKOPEO_INSPECT=${SKOPEO_INSPECT:-$(dirname "${BASH_SOURCE[0]}")/skopeo-inspect.sh}
+
+function proviso() {
+  local -n input=$1
+  local -n output=$2
+
+  local missing image
+  local -a images filtered
+
+  missing=$(mktemp)
+  trap 'rm -f $missing' RETURN
+
+  mapfile -t images < <(jq -r '.meta.images[0]|select(.!=null)' <<<"${input[@]}")
+
+  echo "${images[@]}" |
+    command xargs -n 1 -P 0 "$SKOPEO_INSPECT" "$missing"
+
+  for in in "${input[@]}"; do
+    image=$(jq -r '.meta.images[0]' <<<"$in")
+
+    [[ $image == null ]] && continue
+
+    if command grep "$image" "$missing" &>/dev/null; then
+      filtered+=("$in")
+    fi
+  done
+
+  output=$(command jq -cs '. += $p' --argjson p "$output" <<<"${filtered[@]}")
+}

--- a/src/blocktypes/proviso/skopeo-inspect.sh
+++ b/src/blocktypes/proviso/skopeo-inspect.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+if ! command skopeo inspect --insecure-policy "docker://$2" &>/dev/null; then
+  echo "$2" >>"$1"
+fi

--- a/src/mkCommand.nix
+++ b/src/mkCommand.nix
@@ -1,13 +1,10 @@
 {nixpkgs}: let
-  mkCommand = system: args: let
-    inherit (nixpkgs.legacyPackages.${system}) pkgs;
+  mkCommand = currentSystem: args: let
+    inherit (nixpkgs.legacyPackages.${currentSystem}) pkgs;
   in
     args
     // {
-      command = (pkgs.writeShellScript "${args.name}" args.command).overrideAttrs (_:
-        pkgs.lib.optionalAttrs (args ? provisory) {
-          __provisory = builtins.unsafeDiscardStringContext args.provisory;
-        });
+      command = pkgs.writeShellScript "${args.name}" args.command;
     };
 in
   mkCommand

--- a/src/mkCommand.nix
+++ b/src/mkCommand.nix
@@ -1,5 +1,13 @@
 {nixpkgs}: let
-  writeShellScript = currentSystem: nixpkgs.legacyPackages.${currentSystem}.writeShellScript;
-  mkCommand = currentSystem: args: args // {command = writeShellScript currentSystem "${args.name}" args.command;};
+  mkCommand = system: args: let
+    inherit (nixpkgs.legacyPackages.${system}) pkgs;
+  in
+    args
+    // {
+      command = (pkgs.writeShellScript "${args.name}" args.command).overrideAttrs (_:
+        pkgs.lib.optionalAttrs (args ? provisory) {
+          __provisory = builtins.unsafeDiscardStringContext args.provisory;
+        });
+    };
 in
   mkCommand


### PR DESCRIPTION
This lays the groundwork for more control over how we implement them.

Users can now set an arbitrary number of tags for an image and upload all the given tags. To specify tags, set `meta.tags` to a list of your desire tags in the arguments to `mkOCI` or `mkStandardOCI`. 

The first tag is special in that it is used as the tag checked in the proviso for existence. That way, one can use a Nix input hash as the first tag to only upload when the derivation inside the image actually changes, while still tagging the images that are uploaded with useful tags like the git revision.

If no tags are set, the default upstream tagging mechanism of nix2container is used.