### PR TITLE
refactor: actions must run under currentSystem; clarify that

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,16 +187,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1676683211,
-        "narHash": "sha256-5pkyVT4UF89QhEGH/vb7JgbGsOW76bTDtdNETUJtAqA=",
-        "owner": "divnix",
-        "repo": "paisano",
-        "rev": "63b36b54d5368722e386e16f8e0827dc75165f06",
+        "lastModified": 1677289518,
+        "narHash": "sha256-P3DlNfkmfhQMKgcaAfobxkdRNDkqPJtxgCxMTvl86Nw=",
+        "owner": "paisano-nix",
+        "repo": "core",
+        "rev": "64026ed84100940ecbfbe4056b2f072138155d00",
         "type": "github"
       },
       "original": {
-        "owner": "divnix",
-        "repo": "paisano",
+        "owner": "paisano-nix",
+        "repo": "core",
         "type": "github"
       }
     },
@@ -230,11 +230,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667096281,
-        "narHash": "sha256-wRRec6ze0gJHmGn6m57/zhz/Kdvp9HS4Nl5fkQ+uIuA=",
+        "lastModified": 1677285314,
+        "narHash": "sha256-hlAcg2514zKrPu8jn24BUsIjjvXvCLdw1jvKgBTpqko=",
         "owner": "divnix",
         "repo": "yants",
-        "rev": "d18f356ec25cb94dc9c275870c3a7927a10f8c3c",
+        "rev": "9eab24b273ce021406c852166c216b86e2bb4ec4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677289518,
-        "narHash": "sha256-P3DlNfkmfhQMKgcaAfobxkdRNDkqPJtxgCxMTvl86Nw=",
+        "lastModified": 1677298389,
+        "narHash": "sha256-gNOsmmr3HiNXFaQ+Rc4USFoKksS+6KKZpCTThnnwW6Q=",
         "owner": "paisano-nix",
         "repo": "core",
-        "rev": "64026ed84100940ecbfbe4056b2f072138155d00",
+        "rev": "687683ae1d9028135a43ed1f9cc3954cf55fc689",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
   description = "The Nix Flakes framework for perfectionists with deadlines";
   # override downstream with inputs.std.inputs.nixpkgs.follows = ...
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-  inputs.paisano.url = "github:divnix/paisano";
+  inputs.paisano.url = "github:paisano-nix/core";
   inputs.paisano.inputs.nixpkgs.follows = "nixpkgs";
   inputs.paisano.inputs.yants.follows = "yants";
   inputs.yants.url = "github:divnix/yants";
@@ -55,8 +55,17 @@
         (blockTypes.installables "packages")
       ],
       ...
-    } @ args:
-      inputs.paisano.growOn (args // {inherit cellBlocks;}) {
+    } @ args: let
+      # preserve pos of `cellBlocks` if not using the default
+      args' =
+        args
+        // (
+          if args ? cellBlocks
+          then {}
+          else {inherit cellBlocks;}
+        );
+    in
+      inputs.paisano.growOn args' {
         # standard-specific quality-of-life assets
         __std.direnv_lib = ./direnv_lib.sh;
         __std.nixConfig = let

--- a/src/actions.nix
+++ b/src/actions.nix
@@ -4,8 +4,8 @@
 
   contextFreeDrv = target: l.unsafeDiscardStringContext target.drvPath;
 
-  build = system: target:
-    mkCommand system {
+  build = currentSystem: target:
+    mkCommand currentSystem {
       name = "build";
       description = "build it";
       command = ''
@@ -45,12 +45,12 @@
         '';
     };
 
-  run = system: target: let
+  run = currentSystem: target: let
     programName =
       target.meta.mainProgram
       or (l.getName target);
   in
-    mkCommand system {
+    mkCommand currentSystem {
       name = "run";
       description = "run it";
       # this is the exact sequence mentioned by the `nix run` docs

--- a/src/blocktypes/arion.nix
+++ b/src/blocktypes/arion.nix
@@ -18,49 +18,49 @@
     inherit name;
     type = "arion";
     actions = {
-      system,
+      currentSystem,
       fragment,
       fragmentRelPath,
       target,
     }: let
       cmd = "arion --prebuilt-file ${target.config.out.dockerComposeYaml}";
     in [
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "up";
         description = "arion up";
         command = ''
           ${cmd} up "$@"
         '';
       })
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "ps";
         description = "exec this arion task to ps";
         command = ''
           ${cmd} ps "$@"
         '';
       })
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "stop";
         description = "arion stop";
         command = ''
           ${cmd} stop "$@"
         '';
       })
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "rm";
         description = "arion rm";
         command = ''
           ${cmd} rm "$@"
         '';
       })
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "config";
         description = "check the docker-compose yaml file";
         command = ''
           ${cmd} config "$@"
         '';
       })
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "arion";
         description = "pass any command to arion";
         command = ''

--- a/src/blocktypes/containers.nix
+++ b/src/blocktypes/containers.nix
@@ -18,13 +18,13 @@
     inherit name;
     type = "containers";
     actions = {
-      system,
+      currentSystem,
       fragment,
       fragmentRelPath,
       target,
     }: [
-      (sharedActions.build system target)
-      (mkCommand system {
+      (sharedActions.build currentSystem target)
+      (mkCommand currentSystem {
         name = "print-image";
         description = "print out the image name & tag";
         command = ''
@@ -32,7 +32,7 @@
           echo "${target.imageName}:${target.imageTag}"
         '';
       })
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "publish";
         description = "copy the image to its remote registry";
         command = let
@@ -88,21 +88,21 @@
             }
           '';
       })
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "copy-to-registry";
         description = "copy the image to its remote registry";
         command = ''
           ${target.copyToRegistry}/bin/copy-to-registry
         '';
       })
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "copy-to-docker";
         description = "copy the image to the local docker registry";
         command = ''
           ${target.copyToDockerDaemon}/bin/copy-to-docker-daemon
         '';
       })
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "copy-to-podman";
         description = "copy the image to the local podman registry";
         command = ''

--- a/src/blocktypes/data.nix
+++ b/src/blocktypes/data.nix
@@ -18,12 +18,12 @@
     inherit name;
     type = "data";
     actions = {
-      system,
+      currentSystem,
       fragment,
       fragmentRelPath,
       target,
     }: let
-      inherit (nixpkgs.legacyPackages.${system}) pkgs;
+      inherit (nixpkgs.legacyPackages.${currentSystem}) pkgs;
 
       # if target ? __std_data_wrapper, then we need to unpack from `.data`
       json = pkgs.writeTextFile {
@@ -37,12 +37,12 @@
       jq = ["${pkgs.jq}/bin/jq" "-r" "'.'" "${json}"];
       fx = ["|" "${pkgs.fx}/bin/fx"];
     in [
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "write";
         description = "write to file";
         command = "echo ${json}";
       })
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "explore";
         description = "interactively explore";
         command = l.concatStringsSep "\t" (jq ++ fx);

--- a/src/blocktypes/devshells.nix
+++ b/src/blocktypes/devshells.nix
@@ -17,15 +17,15 @@
     inherit name;
     type = "devshells";
     actions = {
-      system,
+      currentSystem,
       fragment,
       fragmentRelPath,
       target,
     }: let
       developDrv = mkDevelopDrv target;
     in [
-      (sharedActions.build system target)
-      (mkCommand system {
+      (sharedActions.build currentSystem target)
+      (mkCommand currentSystem {
         name = "enter";
         description = "enter this devshell";
         command = ''

--- a/src/blocktypes/files.nix
+++ b/src/blocktypes/files.nix
@@ -13,15 +13,15 @@
     inherit name;
     type = "files";
     actions = {
-      system,
+      currentSystem,
       fragment,
       fragmentRelPath,
       target,
     }: let
       file = toString target;
-      bat = "${nixpkgs.legacyPackages.${system}.bat}/bin/bat";
+      bat = "${nixpkgs.legacyPackages.${currentSystem}.bat}/bin/bat";
     in [
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "explore";
         description = "interactively explore with bat";
         command = ''

--- a/src/blocktypes/installables.nix
+++ b/src/blocktypes/installables.nix
@@ -22,14 +22,14 @@
     inherit name;
     type = "installables";
     actions = {
-      system,
+      currentSystem,
       fragment,
       fragmentRelPath,
       target,
     }: [
-      (sharedActions.build system target)
+      (sharedActions.build currentSystem target)
       # profile commands require a flake ref
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "install";
         description = "install this target";
         command = ''
@@ -41,7 +41,7 @@
           nix profile install $PRJ_ROOT#${fragment}
         '';
       })
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "upgrade";
         description = "upgrade this target";
         command = ''
@@ -53,7 +53,7 @@
           nix profile upgrade $PRJ_ROOT#${fragment}
         '';
       })
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "remove";
         description = "remove this target";
         command = ''
@@ -66,7 +66,7 @@
         '';
       })
       # TODO: use target. `nix bundle` requires a flake ref, but we may be able to use nix-bundle instead as a workaround
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "bundle";
         description = "bundle this target";
         command = ''
@@ -78,7 +78,7 @@
           nix bundle --bundler github:Ninlives/relocatable.nix --refresh $PRJ_ROOT#${fragment}
         '';
       })
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "bundleImage";
         description = "bundle this target to image";
         command = ''
@@ -90,7 +90,7 @@
           nix bundle --bundler github:NixOS/bundlers#toDockerImage --refresh $PRJ_ROOT#${fragment}
         '';
       })
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "bundleAppImage";
         description = "bundle this target to AppImage";
         command = ''

--- a/src/blocktypes/microvms.nix
+++ b/src/blocktypes/microvms.nix
@@ -16,26 +16,26 @@
     inherit name;
     type = "microvms";
     actions = {
-      system,
+      currentSystem,
       fragment,
       fragmentRelPath,
       target,
     }: [
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "run";
         description = "run the microvm";
         command = ''
           ${target.config.microvm.runner.${target.config.microvm.hypervisor}}/bin/microvm-run
         '';
       })
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "console";
         description = "enter the microvm console";
         command = ''
           ${target.config.microvm.runner.${target.config.microvm.hypervisor}}/bin/microvm-console
         '';
       })
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "microvm";
         description = "pass any command to microvm";
         command = ''

--- a/src/blocktypes/nixago.nix
+++ b/src/blocktypes/nixago.nix
@@ -21,23 +21,23 @@
     inherit name;
     type = "nixago";
     actions = {
-      system,
+      currentSystem,
       fragment,
       fragmentRelPath,
       target,
     }: [
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "populate";
         description = "populate this nixago file into the repo";
         command = ''
           ${target.install}/bin/nixago_shell_hook
         '';
       })
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "explore";
         description = "interactively explore the nixago file";
         command = ''
-          ${nixpkgs.legacyPackages.${system}.bat}/bin/bat "${target.configFile}"
+          ${nixpkgs.legacyPackages.${currentSystem}.bat}/bin/bat "${target.configFile}"
         '';
       })
     ];

--- a/src/blocktypes/nomadJobManifests.nix
+++ b/src/blocktypes/nomadJobManifests.nix
@@ -19,14 +19,14 @@
     type = "nomadJobManifests";
 
     actions = {
-      system,
+      currentSystem,
       fragment,
       fragmentRelPath,
       target,
     }: let
-      fx = "${nixpkgs.legacyPackages.${system}.fx}/bin";
-      nomad = "${nixpkgs.legacyPackages.${system}.nomad}/bin";
-      jq = "${nixpkgs.legacyPackages.${system}.jq}/bin";
+      fx = "${nixpkgs.legacyPackages.${currentSystem}.fx}/bin";
+      nomad = "${nixpkgs.legacyPackages.${currentSystem}.nomad}/bin";
+      jq = "${nixpkgs.legacyPackages.${currentSystem}.jq}/bin";
       job = baseNameOf fragmentRelPath;
       nixExpr = ''
         x: let
@@ -74,7 +74,7 @@
       inject the git revision validate the manifest, after which it can be run or
       planned with the Nomad cli or the `deploy` action.
       */
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "render";
         description = "build the JSON job description";
         command =
@@ -87,7 +87,7 @@
             ${render}
           '';
       })
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "deploy";
         description = "Deploy the job to Nomad";
         command =
@@ -129,7 +129,7 @@
             fi
           '';
       })
-      (mkCommand system {
+      (mkCommand currentSystem {
         name = "explore";
         description = "interactively explore the Job defintion";
         command =

--- a/src/blocktypes/runnables.nix
+++ b/src/blocktypes/runnables.nix
@@ -13,13 +13,13 @@
     inherit name;
     type = "runnables";
     actions = {
-      system,
+      currentSystem,
       fragment,
       fragmentRelPath,
       target,
     }: [
-      (sharedActions.build system target)
-      (sharedActions.run system target)
+      (sharedActions.build currentSystem target)
+      (sharedActions.run currentSystem target)
     ];
   };
 in

--- a/src/mkCommand.nix
+++ b/src/mkCommand.nix
@@ -1,5 +1,5 @@
 {nixpkgs}: let
-  writeShellScript = system: nixpkgs.legacyPackages.${system}.writeShellScript;
-  mkCommand = system: args: args // {command = writeShellScript system "${args.name}" args.command;};
+  writeShellScript = currentSystem: nixpkgs.legacyPackages.${currentSystem}.writeShellScript;
+  mkCommand = currentSystem: args: args // {command = writeShellScript currentSystem "${args.name}" args.command;};
 in
   mkCommand


### PR DESCRIPTION

BRAKING CHANGE: the action signature changed: `system` -> `currentSystem`

All ad-hoc actions must be made aware of this change per
this commit as `std` in the short term has lost its deprecation
infrastructure due to the refactoring to `pasiano`