### PR TITLE
fix: ensure old image tag api is consistent

### DIFF
--- a/cells/lib/ops/mkStandardOCI.nix
+++ b/cells/lib/ops/mkStandardOCI.nix
@@ -26,7 +26,7 @@ in
   Returns:
   An OCI container image (created with nix2container).
   */
-  {
+  args @ {
     name,
     operable,
     tag ? "",
@@ -70,7 +70,7 @@ in
     '';
   in
     cell.ops.mkOCI {
-      inherit name tag uid gid labels options perms config meta;
+      inherit name uid gid labels options perms config meta;
       entrypoint = operable';
       setup = [setupLinks] ++ setup;
       runtimeInputs = operable.passthru.runtimeInputs;
@@ -86,3 +86,8 @@ in
         })
       ];
     }
+    // l.throwIf (args ? tag && meta ? tags)
+    "mkStandardOCI: use of `tag` and `meta.tags` arguments are not supported together. Remove the former."
+    (l.optionalAttrs (tag != "") ((import "${inputs.self}/deprecation.nix" inputs).warnLegacyTag {
+      inherit tag;
+    }))

--- a/deprecation.nix
+++ b/deprecation.nix
@@ -37,4 +37,13 @@ in {
     with
       `inputs.std.lib.cfg`
   '';
+  warnLegacyTag = removeBy "July 2023" ''
+    The legacy upstream nix2container tag interface is deprecated,
+    std.lib.ops.mkStandardOCI now takes a list of tags via `meta`.
+
+    Replace `tag` input of `mkStandardOCI` function
+      mkStandardOCI {tag = "foo";/* ... */}
+    with
+      mkStandardOCI {meta.tags = ["foo"]; /* ... */}
+  '';
 }


### PR DESCRIPTION
We don't want users to hit a situation where  they reference one of the legacy n2c APIs such as `imageTag` and get the wrong value.

Therefore, disallow `tag` & `meta.tags` from being set together, always set the first value in `meta.tags` to the legacy `tag` arg of nix2container's `buildImage` function, and warn the user of the deprecated interface when accessed.