### PR TITLE
fix: create /tmp by default for containers

### DIFF
--- a/cells/lib/ops/mkStandardOCI.nix
+++ b/cells/lib/ops/mkStandardOCI.nix
@@ -2,7 +2,7 @@
   inputs,
   cell,
 }: let
-  inherit (inputs) nixpkgs std;
+  inherit (inputs) nixpkgs;
   l = nixpkgs.lib // builtins;
   n2c = inputs.n2c.packages.nix2container;
 in
@@ -62,7 +62,7 @@ in
       else operable;
 
     setupLinks = cell.ops.mkSetup "links" [] ''
-      mkdir -p $out/bin
+      mkdir -p $out/{bin,tmp}
       ${runtimeEntryLink}
       ${debugEntryLink}
       ${livenessLink}


### PR DESCRIPTION
Draft for a potentially richer, optional layer on top of the base image.

brainstorm:
- [ ] existing directories: /tmp, /srv, etc
- [ ] basic /etc: /etc/group, /etc/passwd, etc
- [ ] more powerful debug tools `rg`, `fd` etc
- [ ] potential base image (alpine?)
- [ ] ?