### PR TITLE
fix: don't allow defining broken image

### DIFF
--- a/cells/lib/ops/mkStandardOCI.nix
+++ b/cells/lib/ops/mkStandardOCI.nix
@@ -2,7 +2,7 @@
   inputs,
   cell,
 }: let
-  inherit (inputs) nixpkgs std;
+  inherit (inputs) nixpkgs;
   l = nixpkgs.lib // builtins;
   n2c = inputs.n2c.packages.nix2container;
 in


### PR DESCRIPTION
`recursiveUpdate` takes precedence on the right hand side, and does not merge lists, so the user can overwriting important options set by mk*OCI functions, and end up with a borked image. Instead make the options set by these functions take precedence, and allow `copyToRoot` to be merged cleanly from the one set in `options`.