### PR TITLE
feat: remove the legacy copyTo contracts from n2c images

### DIFF
--- a/cells/lib/ops/mkOCI.nix
+++ b/cells/lib/ops/mkOCI.nix
@@ -92,5 +92,12 @@ in
       // l.throwIf (args ? tag && meta ? tags)
       "mkOCI: use of `tag` and `meta.tags` arguments are not supported together. Remove the former."
       (l.optionalAttrs (tag != "") {inherit tag;});
+
+    image = n2c.buildImage (l.recursiveUpdate options options');
   in
-    n2c.buildImage (l.recursiveUpdate options options')
+    l.removeAttrs image [
+      "copyTo"
+      "copyToDockerDaemon"
+      "copyToPodman"
+      "copyToRegistry"
+    ]


### PR DESCRIPTION
These don't work with the multitags and are a concatenation
of build & metadata in the same implementation.

The multitag feature surfaced these shortcomings and hence
we should remove these facilities to avoid people using
(and cementing usage of) a non-public api because of habit.
