### PR TITLE
fix: allow /bin/sh to accept arguments

### DIFF
--- a/cells/lib/ops/mkOperable.nix
+++ b/cells/lib/ops/mkOperable.nix
@@ -40,7 +40,7 @@ in
       inherit runtimeEnv runtimeInputs runtimeShell;
       name = "runtime";
       text = ''
-        exec -a "$0" ${runtimeShellBin}
+        exec -a "$0" ${runtimeShellBin} "$@"
       '';
     };
 


### PR DESCRIPTION
Necessary for programs that rely on it and pass arguments to it.