### PR TITLE
fix: exec operable script

### DIFF
--- a/cells/lib/ops/mkStandardOCI.nix
+++ b/cells/lib/ops/mkStandardOCI.nix
@@ -60,7 +60,7 @@ in
           >&2 "Sleeping for $DEBUG_SLEEP for debugging"
           sleep "$DEBUG_SLEEP"
         fi
-        ${l.getExe operable} "$@"
+        exec ${l.getExe operable} "$@"
       '';
     };
     operable' =


### PR DESCRIPTION
If the script is not `exec`ed, then it cannot properly respond to any
signals that might be meant for the main process.