### PR TITLE
fix: Specify type/schema for nix build in direnv integration

### DIFF
--- a/direnv_lib.sh
+++ b/direnv_lib.sh
@@ -69,7 +69,7 @@ use_std() {
 
   mkdir -p "$(direnv_layout_dir)/$block/$organ/$target"
 
-  enter="$(nix build "$PWD#__std.actions.$system.$block.$organ.$target.enter" "${nix_args[@]}" --print-out-paths --profile "$profile_path/enter-action")"
+  enter="$(nix build "git+file://$PWD#__std.actions.$system.$block.$organ.$target.enter" "${nix_args[@]}" --print-out-paths --profile "$profile_path/enter-action")"
   export STD_DIRENV=1
   eval "$(<"$enter")"
   # this is not true


### PR DESCRIPTION
Prior to this change, if `$PWD` contains an `@` then the `nix build` fails due to nix being unable to guess the schema/type for the URL.

For example;

```console
$ cd /tmp/

$ git clone https://github.com/divnix/std.git @some_path
Cloning into '@some_path'...
remote: Enumerating objects: 7598, done.
remote: Counting objects: 100% (103/103), done.
remote: Compressing objects: 100% (51/51), done.
remote: Total 7598 (delta 57), reused 86 (delta 51), pack-reused 7495
Receiving objects: 100% (7598/7598), 5.49 MiB | 1.18 MiB/s, done.
Resolving deltas: 100% (4983/4983), done.

$ cd @some_path

$ direnv allow
direnv: loading /tmp/@some_path/.envrc
direnv: using std cells //_automation/devshells:default
direnv: Watching: cells/_automation/devshells.nix
direnv: Watching: cells/_automation/devshells (recursively)
error: '/tmp/@some_path#__std.actions.x86_64-linux._automation.devshells.default.enter' is not a valid URL
/nix/store/9gknmnp1ppjhv4ljvr57bg688x44w8sl-source/direnv_lib.sh:74: : No such file or directory
direnv: export +PRJ_CACHE_DIR +PRJ_DATA_DIR +PRJ_ROOT ~PATH
```

This fix makes the type in the URL explicitly `git+file` which resolves the issue.

I was momentarily concerned that setting the type explicitly like this might mess with some other edge case. However, since the integration starts with `direnv_layout_dir=$(git rev-parse --show-toplevel)/.std` assuming `git+file` would seem same.