### PR TITLE
fix: add prj-spec dirs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,14 @@
 /**/flake.lock
 result
 
+# prj-spec dirs
+# <https://github.com/numtide/prj-spec>
+.bin
+.cache
+.config
+.data
+.run
+
 # nixago: ignore-linked-files
 /cog.toml
 /adrgen.config.yml


### PR DESCRIPTION
On a fresh update of my local copy of the repo,
`.data/` was listed in the untracked files.
