### PR TITLE
fix(templates/rust): allow rust devshell startup to run 'direnv allow' multiple time, idempotently

### DIFF
--- a/src/std/templates/rust/nix/repo/shells.nix
+++ b/src/std/templates/rust/nix/repo/shells.nix
@@ -23,7 +23,7 @@
       text = ''
         # ensure CARGO_HOME is populated
         mkdir -p $PRJ_DATA_DIR/cargo
-        ln -s -t $PRJ_DATA_DIR/cargo $(ls -d ${cell.rust.toolchain}/*)
+        ln -snf -t $PRJ_DATA_DIR/cargo $(ls -d ${cell.rust.toolchain}/*)
       '';
     };
 

--- a/src/tests/checks.nix
+++ b/src/tests/checks.nix
@@ -2,7 +2,6 @@ let
   inherit (inputs) namaka self;
   inputs' = builtins.removeAttrs inputs ["self"];
 in {
-  inherit inputs;
   snapshots = {
     meta.description = "The main Standard Snapshotting test suite";
     check = namaka.lib.load {


### PR DESCRIPTION
This PR replaces previous behavior into symlink + replace whenever reload is triggered. This allows for success `direnv allow`.

# Previous symptoms

```
% ❯ direnv allow
direnv: loading ~/local_repos/zork/.envrc                                                     
/nix/store/20izn153a86zz6wp3b1pbgf4hgvvvcz5-source
direnv: PRJ_ROOT:        /Users/hungtran/local_repos/zork
direnv: PRJ_ID:          none
direnv: PRJ_CONFIG_HOME: .config
direnv: PRJ_RUNTIME_DIR: .run
direnv: PRJ_CACHE_HOME:  .cache
direnv: PRJ_DATA_HOME:   .data
direnv: PRJ_PATH:        .bin
direnv: using envreload //repo/userShells/hungtran //repo/userShells/default //repo/userShells
direnv: Watching: nix/repo/userShells.nix
direnv: Watching: nix/repo/userShells.nix
direnv: Watching: nix/repo/userShells.nix
evaluating derivation 'git+file:///Users/hungtran/local_repos/zork#__std.actions.aarch64-darw
direnv: ([/nix/store/0zay0jgkxqjd6ij07190s66765glhf3w-direnv-2.32.3/bin/direnv export zsh]) is
 taking a while to execute. Use CTRL-C to give up.
ln: /Users/hungtran/local_repos/zork/.data/cargo//Library: File exists
ln: /Users/hungtran/local_repos/zork/.data/cargo//bin: File exists
ln: /Users/hungtran/local_repos/zork/.data/cargo//include: File exists
ln: /Users/hungtran/local_repos/zork/.data/cargo//lib: File exists
ln: /Users/hungtran/local_repos/zork/.data/cargo//libexec: File exists
ln: /Users/hungtran/local_repos/zork/.data/cargo//nix-support: File exists
ln: /Users/hungtran/local_repos/zork/.data/cargo//resource-root: File exists
ln: /Users/hungtran/local_repos/zork/.data/cargo//share: File exists
ln: /Users/hungtran/local_repos/zork/.data/cargo//src: File exists
/Users/hungtran/.cache/direnv/cas/22042128aed41cbd407c2527b493b62826880c9428b519cadaa0b80dac64
fb02:121: pop_var_context: head of shell_variables not a function context
environment:1073: pop_var_context: head of shell_variables not a function context
./.envrc:11: pop_var_context: head of shell_variables not a function context
direnv: error exit status 1

% ❯ rm -rf .data
% ❯ direnv allow
...
% ❯ echo $?
0
```