### PR TITLE
fix(lib/ops): tag defaulting while forwarding mkStandardOCI to mkOCI

### DIFF
--- a/src/lib/ops/mkStandardOCI.nix
+++ b/src/lib/ops/mkStandardOCI.nix
@@ -106,14 +106,15 @@ in
     '';
   in
     with dmerge;
-      l.throwIf (args ? tag && meta ? tags)
-      "mkStandardOCI: use of `tag` and `meta.tags` arguments are not supported together. Remove the former."
       cell.ops.mkOCI (
         merge
-        {
-          inherit name tag uid gid labels options perms config meta setup runtimeInputs;
-          entrypoint = operable';
-        }
+        ({
+            inherit name uid gid labels options perms config meta setup runtimeInputs;
+            entrypoint = operable';
+          }
+          # keep this optional so that mkOCI can likewise
+          # match undefined on args ? tag
+          // l.optionalAttrs (args ? tag) {inherit tag;})
         {
           # mkStandardOCI differentiators over mkOCI
           # - live & readiness probes

--- a/src/local/flake.lock
+++ b/src/local/flake.lock
@@ -521,12 +521,12 @@
       },
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-QL0eHRF59MaRUbT+pckQq0bbcdQkpRZMFeFw3inw50Y=",
-        "path": "/nix/store/xyknmk3cmq5ihf75nx6xa12mayklb19y-source",
+        "narHash": "sha256-ZEESiQYrqHYWDG4MceGyn4dkePammw0wv4vQHlzmw0w=",
+        "path": "/nix/store/lhia7f9wjdkv3cghisnsk3gr1pk9xzw6-source",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/xyknmk3cmq5ihf75nx6xa12mayklb19y-source",
+        "path": "/nix/store/lhia7f9wjdkv3cghisnsk3gr1pk9xzw6-source",
         "type": "path"
       }
     },

--- a/src/tests/flake.lock
+++ b/src/tests/flake.lock
@@ -532,12 +532,12 @@
       },
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-zapgEDNJVPbaAprJw+pl32jJDNtpjpQiTdulfF9wNAo=",
-        "path": "/nix/store/g2jz5pi1rc615b4hrijw6nbd4gw56cpw-source",
+        "narHash": "sha256-Etr7kGjXf+x9nKBU20zWlp2c5+dYytwcHwsPWeLnEY4=",
+        "path": "/nix/store/xxs06c49yw8j0wizyib4d0dmqmrdfzi7-source",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/g2jz5pi1rc615b4hrijw6nbd4gw56cpw-source",
+        "path": "/nix/store/xxs06c49yw8j0wizyib4d0dmqmrdfzi7-source",
         "type": "path"
       }
     },


### PR DESCRIPTION
# Context

A bit of an advanced nix foo is to dectect argument definition not
by value, but by leveraging the way attrs function defaulting works:

In `args @ { foo ? null, ... }`, args only has an argument `foo`,
if foo was defined by the caller. `foo` would still be `null`, but
`args.foo` does not exist.

mkOCI leverages this to collate the two means by which an image
tag can be defined `args.tag` & `args.meta.tags`.

# Issue and Solution

This fix passes on this relevant calling context from `mkStandardOCI`
down to `mkOCI` which will then correctly perform the checks and
collation of values.

Prior to this PR, a recent refactoring had produced a regression
where `mkOCI` had _always_ complained if the user had set `args.meta.tags`
due to that from the `mkOCI` perspective, `args.tag` was _also_
(erroneously) passed down from `mkStandardOCI`
