### PR TITLE
fix(ops/mkDevOCI): avoid undue symlink and improve ux

### DIFF
--- a/src/lib/ops/mkDevOCI.nix
+++ b/src/lib/ops/mkDevOCI.nix
@@ -92,8 +92,8 @@ in
 
         # Enable nix flakes
         mkdir -p $out/etc
-        echo "sandbox = false" > $out/etc/nix.conf
-        echo "accept-flake-config = true" > $out/etc/nix.conf
+        echo "sandbox = false" >> $out/etc/nix.conf
+        echo "accept-flake-config = true" >> $out/etc/nix.conf
         echo "experimental-features = nix-command flakes" >> $out/etc/nix.conf
 
         # Increase warn timeout and whitelist all paths

--- a/src/lib/ops/mkOCI.nix
+++ b/src/lib/ops/mkOCI.nix
@@ -81,7 +81,7 @@ in
                 paths =
                   setup
                   ++ [
-                    # prevent the $out`/bin` to be a symlink
+                    # trick `buildEnv` and prevent the $out`/bin` to be a symlink
                     (nixpkgs.runCommand "setupDirs" {}
                       ''
                         mkdir -p $out/bin

--- a/src/lib/ops/mkOCI.nix
+++ b/src/lib/ops/mkOCI.nix
@@ -78,7 +78,16 @@ in
             [
               (nixpkgs.buildEnv {
                 name = "root";
-                paths = [setupLinks] ++ setup;
+                paths =
+                  setup
+                  ++ [
+                    # prevent the $out`/bin` to be a symlink
+                    (nixpkgs.runCommand "setupDirs" {}
+                      ''
+                        mkdir -p $out/bin
+                      '')
+                    setupLinks
+                  ];
               })
             ]
             ++ options.copyToRoot or [];


### PR DESCRIPTION
fixes: #333 

It appears that putting those two stages together would result in the entrypoints being overwritten.