### PR TITLE
Improve the UX for mkDevOCI

### DIFF
--- a/src/lib/ops/mkDevOCI.nix
+++ b/src/lib/ops/mkDevOCI.nix
@@ -91,6 +91,7 @@ in
         # Enable nix flakes
         mkdir -p $out/etc
         echo "sandbox = false" > $out/etc/nix.conf
+        echo "accept-flake-config = true" > $out/etc/nix.conf
         echo "experimental-features = nix-command flakes" >> $out/etc/nix.conf
 
         # Increase warn timeout and whitelist all paths

--- a/src/lib/ops/mkDevOCI.nix
+++ b/src/lib/ops/mkDevOCI.nix
@@ -31,6 +31,7 @@ in
   automatically prefixed with "org.opencontainers.image".
   config: Additional options to pass to nix2container.buildImage's config.
   options: Additional options to pass to nix2container.buildImage.
+  preLoadStorePaths: A list of store paths to preload/copy into the container.
 
   Returns:
   An OCI container image (created with nix2container).
@@ -45,6 +46,7 @@ in
     tag ? null,
     pkgs ? [],
     setup ? [],
+    preLoadStorePaths ? [],
     perms ? [],
     labels ? {},
     config ? {},
@@ -205,6 +207,7 @@ in
 
       layers = [
         (n2c.buildLayer {
+          deps = preLoadStorePaths;
           copyToRoot = [
             (nixpkgs.buildEnv
               {


### PR DESCRIPTION
# Context

When working with Dev Containers, we are in the Dev X domain, where speed and "no-unexpected-warnings" matter.

# Proposal

- Avoid unexpected warnings by setting `accept-flake-config = true`; using flake level config is general practice in `std`-like projects where a Nix Power User provides an environment for team colleagues. The warnings are technically accurately motivated, but in practice just too noisy for these scenarios where the power user is trusted.

- `preLoadStorePaths: A list of store paths to preload/copy into the container.`: This helps speed things up. You can preload some store paths to make the loading of the dev container faster for the user (i.e. avoid lazy fetching during startup by already baking those paths into the image)