### PR TITLE
fix(kubectl): diff action and differ command

### DIFF
--- a/src/std/fwlib/blockTypes/kubectl.nix
+++ b/src/std/fwlib/blockTypes/kubectl.nix
@@ -123,11 +123,11 @@ in
         ${build}
         build
 
-        KUBECTL_EXTERNAL_DIFF="icdiff -N -u"
+        KUBECTL_EXTERNAL_DIFF="icdiff -N -r"
         export KUBECTL_EXTERNAL_DIFF
 
         diff() {
-          kubectl diff --server-side=true --field-manager="std-action-$(whoami)" ${
+          kubectl diff ${
           if usesKustomize
           then "--kustomize"
           else "--filename --recursive"
@@ -140,7 +140,7 @@ in
         ${build}
         build
 
-        KUBECTL_EXTERNAL_DIFF="icdiff -N -u"
+        KUBECTL_EXTERNAL_DIFF="icdiff -N -r"
         export KUBECTL_EXTERNAL_DIFF
 
         diff() {


### PR DESCRIPTION
# Context

The invocation of `icdiff` needs to be `-r`ecursive.

Furthermore, when `:diff` action is employed locally, server side apply would conflict (e.g. if `:apply` is reserved for a CI/CD actor) on field ownership and therefore may not be used.
