### PR TITLE
feat(namaka): allow overriding [dir] and allow snapshots to be generated/changed within std

### DIFF
--- a/src/std/fwlib/blockTypes/namaka.nix
+++ b/src/std/fwlib/blockTypes/namaka.nix
@@ -26,13 +26,13 @@ in
         nix eval '.#${fragment}.check'
       '' {})
       (mkCommand currentSystem "check" "run namaka tests against snapshots" [pkg] ''
-        namaka ${subdir} check -c nix eval '.#${fragment}.check'
+        namaka ${subdir} check -c nix eval '.#${fragment}'
       '' {})
       (mkCommand currentSystem "review" "review pending namaka checks" [pkg] ''
-        namaka ${subdir} review -c nix eval '.#${fragment}.check'
+        namaka ${subdir} review -c nix eval '.#${fragment}'
       '' {})
       (mkCommand currentSystem "clean" "clean up pending namaka checks" [pkg] ''
-        namaka ${subdir} clean -c nix eval '.#${fragment}.check'
+        namaka ${subdir} clean -c nix eval '.#${fragment}'
       '' {})
     ];
   }

--- a/src/std/fwlib/blockTypes/namaka.nix
+++ b/src/std/fwlib/blockTypes/namaka.nix
@@ -17,18 +17,19 @@ in
       inputs,
     }: let
       pkg = inputs.namaka.packages.${currentSystem}.default;
+      subdir = target.snap-dir or "";
     in [
       (mkCommand currentSystem "eval" "use transparently with namaka cli" [] ''
         nix eval '.#${fragment}.check'
       '' {})
       (mkCommand currentSystem "check" "run namaka tests against snapshots" [pkg] ''
-        namaka check -c nix eval '.#${fragment}.check'
+        namaka "${subdir}" check -c nix eval '.#${fragment}.check'
       '' {})
       (mkCommand currentSystem "review" "review pending namaka checks" [pkg] ''
-        namaka review -c nix eval '.#${fragment}.check'
+        namaka "${subdir}" review -c nix eval '.#${fragment}.check'
       '' {})
       (mkCommand currentSystem "clean" "clean up pending namaka checks" [pkg] ''
-        namaka clean -c nix eval '.#${fragment}.check'
+        namaka "${subdir}" clean -c nix eval '.#${fragment}.check'
       '' {})
     ];
   }

--- a/src/std/fwlib/blockTypes/namaka.nix
+++ b/src/std/fwlib/blockTypes/namaka.nix
@@ -23,7 +23,7 @@ in
         else "";
     in [
       (mkCommand currentSystem "eval" "use transparently with namaka cli" [] ''
-        nix eval '.#${fragment}.check'
+        nix eval '.#${fragment}'
       '' {})
       (mkCommand currentSystem "check" "run namaka tests against snapshots" [pkg] ''
         namaka ${subdir} check -c nix eval '.#${fragment}'

--- a/src/std/fwlib/blockTypes/namaka.nix
+++ b/src/std/fwlib/blockTypes/namaka.nix
@@ -17,19 +17,22 @@ in
       inputs,
     }: let
       pkg = inputs.namaka.packages.${currentSystem}.default;
-      subdir = target.snap-dir or "";
+      subdir =
+        if target ? "snap-dir"
+        then "${target.snap-dir}"
+        else "";
     in [
       (mkCommand currentSystem "eval" "use transparently with namaka cli" [] ''
         nix eval '.#${fragment}.check'
       '' {})
       (mkCommand currentSystem "check" "run namaka tests against snapshots" [pkg] ''
-        namaka "${subdir}" check -c nix eval '.#${fragment}.check'
+        namaka ${subdir} check -c nix eval '.#${fragment}.check'
       '' {})
       (mkCommand currentSystem "review" "review pending namaka checks" [pkg] ''
-        namaka "${subdir}" review -c nix eval '.#${fragment}.check'
+        namaka ${subdir} review -c nix eval '.#${fragment}.check'
       '' {})
       (mkCommand currentSystem "clean" "clean up pending namaka checks" [pkg] ''
-        namaka "${subdir}" clean -c nix eval '.#${fragment}.check'
+        namaka ${subdir} clean -c nix eval '.#${fragment}.check'
       '' {})
     ];
   }


### PR DESCRIPTION
### Overriding `[dir]`

This allows you to put in `snap-dir`

```nix
# nix/local/tests/default.nix
{inputs, cell}:
{
  snapshots = {
    meta.description="your desc"; 
    check = namaka.lib.load {...}; 
    snap-dir = "nix";
  };
}
```

Consider that your repo wants to have everything nix (apart from flake.nix) to be in nix/ or contrib/, maybe due to some kind of code ownership system. 

You now have the option to put snapshots inside of the respective `[dir]`

### Dealing with changing snapshots in std

Here's the reproducing bash that this change allows.

<details>
<summary>

```bash
rm -rf tests/_snapshots
git add tests/
# (all fine)
std //tests/checks/snapshots:check
```

</summary>

```
------------------------------------------------------------------
Executing /Users/<user>/local_repos/std/.local/state/last-action
With args []
------------------------------------------------------------------
🞥 bt-blocktypes
🞥 check-augmented-cell-inputs
🞥 flake-module
🞥 cells-lib-ops
🞥 cells-lib-cfg
🞥 cells-lib-dev
6 out of 6 tests failed
```

</details>

```bash
std //tests/checks/snapshots:review
```

```

# before>
------------------------------------------------------------------
Executing /Users/<user>/local_repos/std/.local/state/last-action
With args []
------------------------------------------------------------------
warning: Git tree '/Users/<user>/local_repos/std' is dirty
error: cached failure of attribute 'aarch64-darwin.tests.checks.snapshots.check'
Error: 
   0: unknown error

Location:
   src/cmd/review.rs:84

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
####
# after>
(goes thru prompts correctly and there is no git diff)
```

#### Correctness

Basically `check = namaka.lib.load {...};` actually just returns `{}` and relies heavily on the tracing and assertion system of Nix. 

Since `nix eval` realizes `.check` anyways (and `namaka.lib.load` only traces its managed hierarchy), there's realistically no difference on the `nix eval` to include `.check` or not, we just need to make sure:
1. To realize ONLY the set of snapshots we're interested in (I haven't tried the case of many snapshots yet, but this doesn't change the previous behavior)
2. `std` is able to do its mapping magic


The `std` magic to pass this around into `./#${system}.${cell}.${cellBlock}.snapshots.check` gets the error assertion in case of snapshot mismatch (or non-existence), which prevents the `std` magic to finish, resulting in obscure error message. 

Removing `.check` lets this go through to `nix eval`, which still prints the correct `trace: namaka={JSON as if we index inside .check}` and to be compared with the correct snapshot path from `namaka.lib.load`.