### PR TITLE
fix: broken `lib` follows

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,8 +36,7 @@
           "haumea"
         ],
         "nixlib": [
-          "haumea",
-          "nixpkgs"
+          "lib"
         ],
         "yants": [
           "yants"
@@ -80,8 +79,7 @@
     "incl": {
       "inputs": {
         "nixlib": [
-          "haumea",
-          "nixpkgs"
+          "lib"
         ]
       },
       "locked": {
@@ -95,6 +93,21 @@
       "original": {
         "owner": "divnix",
         "repo": "incl",
+        "type": "github"
+      }
+    },
+    "lib": {
+      "locked": {
+        "lastModified": 1694306727,
+        "narHash": "sha256-26fkTOJOI65NOTNKFvtcJF9mzzf/kK9swHzfYt1Dl6Q=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "c30b6a84c0b84ec7aecbe74466033facc9ed103f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
         "type": "github"
       }
     },
@@ -198,6 +211,7 @@
         "dmerge": "dmerge",
         "haumea": "haumea",
         "incl": "incl",
+        "lib": "lib",
         "makes": [
           "blank"
         ],

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,7 @@
   description = "The Nix Flakes framework for perfectionists with deadlines";
   # override downstream with inputs.std.inputs.nixpkgs.follows = ...
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  inputs.lib.url = "github:nix-community/nixpkgs.lib";
   inputs = {
     paisano.url = "github:paisano-nix/core";
     paisano.inputs.nixpkgs.follows = "nixpkgs";
@@ -24,14 +25,14 @@
     url = "github:divnix/dmerge/0.2.1";
     inputs.haumea.follows = "haumea";
     inputs.yants.follows = "yants";
-    inputs.nixlib.follows = "haumea/nixpkgs";
+    inputs.nixlib.follows = "lib";
   };
   inputs.haumea = {
     url = "github:nix-community/haumea/v0.2.2";
   };
   inputs.incl = {
     url = "github:divnix/incl";
-    inputs.nixlib.follows = "haumea/nixpkgs";
+    inputs.nixlib.follows = "lib";
   };
   /*
   Auxiliar inputs used in builtin libraries or for the dev environment.

--- a/tests/_snapshots/check-augmented-cell-inputs
+++ b/tests/_snapshots/check-augmented-cell-inputs
@@ -8,6 +8,7 @@
   flake-parts = "/nix/store/jiyanhix45y0a7m9nsrng44yjzrp79m9-source";
   haumea = "/nix/store/ih873qmabdsdgk1naaiv6v7jy1mxq241-source";
   incl = "/nix/store/4dqlpd9c8yil4ay4prr38vslxhpsp4zp-source";
+  lib = "/nix/store/2rv5rbn68fjpc2lhs7wyxyisa4vyxn6a-source";
   makes = "/nix/store/71rzg7vs53gmxqph64d9zqf4ns928c6c-source";
   microvm = "/nix/store/v5za7dzczgcvfvqgcm80qari3msyhw6b-source";
   n2c = "/nix/store/rgd4s5ylv38p94wi6vays6wc1a0l5iyf-source";


### PR DESCRIPTION
# Context

https://github.com/divnix/std/pull/348 propones to add lib as a separate input on the basis of proper semantic distinction between `nixpkgs` and `lib`.
They only happen to be sourcable from the same input, but lib is a library extension of nix and not specific to nixpkgs.

# Proposed solution

Add `lib` as semantically distinct extra input.

https://github.com/divnix/std/pull/348 had some failing tests that this PR hopefully fixes.

