### PR TITLE
refactor/bring data collections back home

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Update subflake references
         run: ./.github/workflows/update-subflake.sh
 
-      - run: nix develop .#book -c mdbook build ./docs
+      - run: nix develop .#book -c mdbook build ./.
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/book.toml
+++ b/book.toml
@@ -1,19 +1,19 @@
 [book]
 language = "en"
 multilingual = false
-src = "."
+src = "docs"
 title = "The Standard Documentation"
 
 [build]
-build-dir = "book"
+build-dir = "docs/book"
 
 [output.html]
-additional-css = ["theme/pagetoc.css"]
-additional-js = ["theme/pagetoc.js"]
+additional-css = ["docs/theme/pagetoc.css"]
+additional-js = ["docs/theme/pagetoc.js"]
 
 [preprocessor.paisano-preprocessor]
 before = ["links"]
-registry = "..#__std.init"
+registry = ".#__std.init"
 
 [[preprocessor.paisano-preprocessor.multi]]
 cell = "lib"

--- a/dogfood.nix
+++ b/dogfood.nix
@@ -20,7 +20,7 @@ in
   }
   (std.grow {
     inherit inputs;
-    cellsFrom = incl ./src ["std" "lib"];
+    cellsFrom = incl ./src ["std" "lib" "data"];
     cellBlocks = with std.blockTypes; [
       ## For downstream use
 
@@ -33,7 +33,8 @@ in
       # lib
       (functions "dev")
       (functions "ops")
-      (nixago "cfg")
+      (anything "cfg")
+      (nixago "configs")
     ];
   })
   {

--- a/src/data/configs/adrgen.nix
+++ b/src/data/configs/adrgen.nix
@@ -1,0 +1,15 @@
+{
+  default_meta = [];
+  default_status = "proposed";
+  directory = "docs/explain/any-decision-records";
+  id_digit_number = 4;
+  supported_statuses = [
+    "proposed"
+    "accepted"
+    "rejected"
+    "superseded"
+    "amended"
+    "deprecated"
+  ];
+  template_file = "docs/explain/any-decision-records/template.md";
+}

--- a/src/data/configs/adrgen.nix
+++ b/src/data/configs/adrgen.nix
@@ -1,15 +1,17 @@
 {
-  default_meta = [];
-  default_status = "proposed";
-  directory = "docs/explain/any-decision-records";
-  id_digit_number = 4;
-  supported_statuses = [
-    "proposed"
-    "accepted"
-    "rejected"
-    "superseded"
-    "amended"
-    "deprecated"
-  ];
-  template_file = "docs/explain/any-decision-records/template.md";
+  data = {
+    default_meta = [];
+    default_status = "proposed";
+    directory = "docs/explain/any-decision-records";
+    id_digit_number = 4;
+    supported_statuses = [
+      "proposed"
+      "accepted"
+      "rejected"
+      "superseded"
+      "amended"
+      "deprecated"
+    ];
+    template_file = "docs/explain/any-decision-records/template.md";
+  };
 }

--- a/src/data/configs/cog.nix
+++ b/src/data/configs/cog.nix
@@ -1,37 +1,39 @@
 {
-  tag_prefix = "v";
-  branch_whitelist = ["main" "release/**"];
-  ignore_merge_commits = true;
-  pre_bump_hooks = [
-    "echo {{version}} > ./VERSION"
-    ''
-      branch="$(echo "release/{{version}}" | sed 's/\.[^.]*$//')"
-      if [ `git rev-parse --verify $branch 2>/dev/null` ]
-      then
-        git switch -m "$branch" || exit 1
-        git merge main
-      else
-        git switch -c "$branch" || exit 1
-      fi
-    ''
-  ];
-  post_bump_hooks = [
-    ''
-      branch="$(echo "release/{{version}}" | sed 's/\.[^.]*$//')"
-      git push --set-upstream origin "$branch"
-      git push origin v{{version}}
+  data = {
+    tag_prefix = "v";
+    branch_whitelist = ["main" "release/**"];
+    ignore_merge_commits = true;
+    pre_bump_hooks = [
+      "echo {{version}} > ./VERSION"
+      ''
+        branch="$(echo "release/{{version}}" | sed 's/\.[^.]*$//')"
+        if [ `git rev-parse --verify $branch 2>/dev/null` ]
+        then
+          git switch -m "$branch" || exit 1
+          git merge main
+        else
+          git switch -c "$branch" || exit 1
+        fi
+      ''
+    ];
+    post_bump_hooks = [
+      ''
+        branch="$(echo "release/{{version}}" | sed 's/\.[^.]*$//')"
+        git push --set-upstream origin "$branch"
+        git push origin v{{version}}
 
-      git switch main
-      git merge "$branch" --no-commit --no-ff
-      echo {{version+minor-dev}} > ./VERSION
-      git add VERSION
-      git commit -m "chore: sync with release"
-      git push origin main
-    ''
-    "cog -q changelog --at v{{version}}"
-  ];
-  changelog = {
-    path = "CHANGELOG.md";
-    template = "remote";
+        git switch main
+        git merge "$branch" --no-commit --no-ff
+        echo {{version+minor-dev}} > ./VERSION
+        git add VERSION
+        git commit -m "chore: sync with release"
+        git push origin main
+      ''
+      "cog -q changelog --at v{{version}}"
+    ];
+    changelog = {
+      path = "CHANGELOG.md";
+      template = "remote";
+    };
   };
 }

--- a/src/data/configs/cog.nix
+++ b/src/data/configs/cog.nix
@@ -1,0 +1,37 @@
+{
+  tag_prefix = "v";
+  branch_whitelist = ["main" "release/**"];
+  ignore_merge_commits = true;
+  pre_bump_hooks = [
+    "echo {{version}} > ./VERSION"
+    ''
+      branch="$(echo "release/{{version}}" | sed 's/\.[^.]*$//')"
+      if [ `git rev-parse --verify $branch 2>/dev/null` ]
+      then
+        git switch -m "$branch" || exit 1
+        git merge main
+      else
+        git switch -c "$branch" || exit 1
+      fi
+    ''
+  ];
+  post_bump_hooks = [
+    ''
+      branch="$(echo "release/{{version}}" | sed 's/\.[^.]*$//')"
+      git push --set-upstream origin "$branch"
+      git push origin v{{version}}
+
+      git switch main
+      git merge "$branch" --no-commit --no-ff
+      echo {{version+minor-dev}} > ./VERSION
+      git add VERSION
+      git commit -m "chore: sync with release"
+      git push origin main
+    ''
+    "cog -q changelog --at v{{version}}"
+  ];
+  changelog = {
+    path = "CHANGELOG.md";
+    template = "remote";
+  };
+}

--- a/src/data/configs/conform.nix
+++ b/src/data/configs/conform.nix
@@ -1,0 +1,20 @@
+{
+  commit = {
+    header = {length = 89;};
+    conventional = {
+      types = [
+        "build"
+        "chore"
+        "ci"
+        "docs"
+        "feat"
+        "fix"
+        "perf"
+        "refactor"
+        "style"
+        "test"
+      ];
+      scopes = [];
+    };
+  };
+}

--- a/src/data/configs/conform.nix
+++ b/src/data/configs/conform.nix
@@ -1,20 +1,22 @@
 {
-  commit = {
-    header = {length = 89;};
-    conventional = {
-      types = [
-        "build"
-        "chore"
-        "ci"
-        "docs"
-        "feat"
-        "fix"
-        "perf"
-        "refactor"
-        "style"
-        "test"
-      ];
-      scopes = [];
+  data = {
+    commit = {
+      header = {length = 89;};
+      conventional = {
+        types = [
+          "build"
+          "chore"
+          "ci"
+          "docs"
+          "feat"
+          "fix"
+          "perf"
+          "refactor"
+          "style"
+          "test"
+        ];
+        scopes = [];
+      };
     };
   };
 }

--- a/src/data/configs/default.nix
+++ b/src/data/configs/default.nix
@@ -1,0 +1,50 @@
+{
+  inputs,
+  cell,
+}: let
+  inherit (inputs) nixpkgs;
+  inherit (inputs.mdbook-paisano-preprocessor.app.package) mdbook-paisano-preprocessor;
+  inherit (inputs.cells.lib) cfg;
+
+  inherit (inputs.nixpkgs.lib) recursiveUpdate;
+in {
+  adrgen = recursiveUpdate cfg.adrgen {
+    data = import ./adrgen.nix;
+  };
+  editorconfig = recursiveUpdate cfg.editorconfig {
+    data = import ./editorconfig.nix;
+    hook.mode = "copy"; # already useful before entering the devshell
+  };
+  conform = recursiveUpdate cfg.conform {
+    data = import ./conform.nix;
+  };
+  lefthook = recursiveUpdate cfg.lefthook {
+    data = import ./lefthook.nix;
+  };
+  mdbook = recursiveUpdate cfg.mdbook {
+    data = import ./mdbook.nix;
+    hook.mode = "copy"; # let CI pick it up outside of devshell
+    packages = [
+      nixpkgs.alejandra
+      nixpkgs.nodePackages.prettier
+      nixpkgs.nodePackages.prettier-plugin-toml
+      nixpkgs.shfmt
+      mdbook-paisano-preprocessor
+    ];
+  };
+  treefmt = recursiveUpdate cfg.treefmt {
+    data = import ./treefmt.nix {inherit (nixpkgs.nodePackages) prettier-plugin-toml;};
+    packages = [
+      nixpkgs.alejandra
+      nixpkgs.nodePackages.prettier
+      nixpkgs.nodePackages.prettier-plugin-toml
+      nixpkgs.shfmt
+    ];
+  };
+  githubsettings = recursiveUpdate cfg.githubsettings {
+    data = import ./githubsettings.nix;
+  };
+  cog = recursiveUpdate cfg.cog {
+    data = import ./cog.nix;
+  };
+}

--- a/src/data/configs/default.nix
+++ b/src/data/configs/default.nix
@@ -8,43 +8,12 @@
 
   inherit (inputs.nixpkgs.lib) recursiveUpdate;
 in {
-  adrgen = recursiveUpdate cfg.adrgen {
-    data = import ./adrgen.nix;
-  };
-  editorconfig = recursiveUpdate cfg.editorconfig {
-    data = import ./editorconfig.nix;
-    hook.mode = "copy"; # already useful before entering the devshell
-  };
-  conform = recursiveUpdate cfg.conform {
-    data = import ./conform.nix;
-  };
-  lefthook = recursiveUpdate cfg.lefthook {
-    data = import ./lefthook.nix;
-  };
-  mdbook = recursiveUpdate cfg.mdbook {
-    data = import ./mdbook.nix;
-    hook.mode = "copy"; # let CI pick it up outside of devshell
-    packages = [
-      nixpkgs.alejandra
-      nixpkgs.nodePackages.prettier
-      nixpkgs.nodePackages.prettier-plugin-toml
-      nixpkgs.shfmt
-      mdbook-paisano-preprocessor
-    ];
-  };
-  treefmt = recursiveUpdate cfg.treefmt {
-    data = import ./treefmt.nix {inherit (nixpkgs.nodePackages) prettier-plugin-toml;};
-    packages = [
-      nixpkgs.alejandra
-      nixpkgs.nodePackages.prettier
-      nixpkgs.nodePackages.prettier-plugin-toml
-      nixpkgs.shfmt
-    ];
-  };
-  githubsettings = recursiveUpdate cfg.githubsettings {
-    data = import ./githubsettings.nix;
-  };
-  cog = recursiveUpdate cfg.cog {
-    data = import ./cog.nix;
-  };
+  adrgen = recursiveUpdate cfg.adrgen (import ./adrgen.nix);
+  editorconfig = recursiveUpdate cfg.editorconfig (import ./editorconfig.nix);
+  conform = recursiveUpdate cfg.conform (import ./conform.nix);
+  lefthook = recursiveUpdate cfg.lefthook (import ./lefthook.nix);
+  mdbook = recursiveUpdate cfg.mdbook (scopedImport {inherit inputs;} ./mdbook.nix);
+  treefmt = recursiveUpdate cfg.treefmt (scopedImport {inherit inputs;} ./treefmt.nix);
+  githubsettings = recursiveUpdate cfg.githubsettings (import ./githubsettings.nix);
+  cog = recursiveUpdate cfg.cog (import ./cog.nix);
 }

--- a/src/data/configs/editorconfig.nix
+++ b/src/data/configs/editorconfig.nix
@@ -1,0 +1,32 @@
+{
+  root = true;
+
+  "*" = {
+    end_of_line = "lf";
+    insert_final_newline = true;
+    trim_trailing_whitespace = true;
+    charset = "utf-8";
+    indent_style = "space";
+    indent_size = 2;
+  };
+
+  "*.{diff,patch}" = {
+    end_of_line = "unset";
+    insert_final_newline = "unset";
+    trim_trailing_whitespace = "unset";
+    indent_size = "unset";
+  };
+
+  "*.md" = {
+    max_line_length = "off";
+    trim_trailing_whitespace = false;
+  };
+  "{LICENSES/**,LICENSE}" = {
+    end_of_line = "unset";
+    insert_final_newline = "unset";
+    trim_trailing_whitespace = "unset";
+    charset = "unset";
+    indent_style = "unset";
+    indent_size = "unset";
+  };
+}

--- a/src/data/configs/editorconfig.nix
+++ b/src/data/configs/editorconfig.nix
@@ -1,32 +1,36 @@
 {
-  root = true;
+  hook.mode = "copy"; # already useful before entering the devshell
 
-  "*" = {
-    end_of_line = "lf";
-    insert_final_newline = true;
-    trim_trailing_whitespace = true;
-    charset = "utf-8";
-    indent_style = "space";
-    indent_size = 2;
-  };
+  data = {
+    root = true;
 
-  "*.{diff,patch}" = {
-    end_of_line = "unset";
-    insert_final_newline = "unset";
-    trim_trailing_whitespace = "unset";
-    indent_size = "unset";
-  };
+    "*" = {
+      end_of_line = "lf";
+      insert_final_newline = true;
+      trim_trailing_whitespace = true;
+      charset = "utf-8";
+      indent_style = "space";
+      indent_size = 2;
+    };
 
-  "*.md" = {
-    max_line_length = "off";
-    trim_trailing_whitespace = false;
-  };
-  "{LICENSES/**,LICENSE}" = {
-    end_of_line = "unset";
-    insert_final_newline = "unset";
-    trim_trailing_whitespace = "unset";
-    charset = "unset";
-    indent_style = "unset";
-    indent_size = "unset";
+    "*.{diff,patch}" = {
+      end_of_line = "unset";
+      insert_final_newline = "unset";
+      trim_trailing_whitespace = "unset";
+      indent_size = "unset";
+    };
+
+    "*.md" = {
+      max_line_length = "off";
+      trim_trailing_whitespace = false;
+    };
+    "{LICENSES/**,LICENSE}" = {
+      end_of_line = "unset";
+      insert_final_newline = "unset";
+      trim_trailing_whitespace = "unset";
+      charset = "unset";
+      indent_style = "unset";
+      indent_size = "unset";
+    };
   };
 }

--- a/src/data/configs/githubsettings.nix
+++ b/src/data/configs/githubsettings.nix
@@ -1,0 +1,124 @@
+let
+  colors = {
+    black = "#000000";
+    blue = "#1565C0";
+    lightBlue = "#64B5F6";
+    green = "#4CAF50";
+    grey = "#A6A6A6";
+    lightGreen = "#81C784";
+    gold = "#FDD835";
+    orange = "#FB8C00";
+    purple = "#AB47BC";
+    red = "#F44336";
+    yellow = "#FFEE58";
+  };
+  labels = {
+    statuses = {
+      abandoned = {
+        name = ":running: Status: Abdandoned";
+        description = "This issue has been abdandoned";
+        color = colors.black;
+      };
+      accepted = {
+        name = ":ok: Status: Accepted";
+        description = "This issue has been accepted";
+        color = colors.green;
+      };
+      blocked = {
+        name = ":x: Status: Blocked";
+        description = "This issue is in a blocking state";
+        color = colors.red;
+      };
+      inProgress = {
+        name = ":construction: Status: In Progress";
+        description = "This issue is actively being worked on";
+        color = colors.grey;
+      };
+      onHold = {
+        name = ":golf: Status: On Hold";
+        description = "This issue is not currently being worked on";
+        color = colors.red;
+      };
+      reviewNeeded = {
+        name = ":eyes: Status: Review Needed";
+        description = "This issue is pending a review";
+        color = colors.gold;
+      };
+    };
+    types = {
+      bug = {
+        name = ":bug: Type: Bug";
+        description = "This issue targets a bug";
+        color = colors.red;
+      };
+      story = {
+        name = ":scroll: Type: Story";
+        description = "This issue targets a new feature through a story";
+        color = colors.lightBlue;
+      };
+      maintenance = {
+        name = ":wrench: Type: Maintenance";
+        description = "This issue targets general maintenance";
+        color = colors.orange;
+      };
+      question = {
+        name = ":grey_question: Type: Question";
+        description = "This issue contains a question";
+        color = colors.purple;
+      };
+      security = {
+        name = ":cop: Type: Security";
+        description = "This issue targets a security vulnerability";
+        color = colors.red;
+      };
+    };
+    priorities = {
+      critical = {
+        name = ":boom: Priority: Critical";
+        description = "This issue is prioritized as critical";
+        color = colors.red;
+      };
+      high = {
+        name = ":fire: Priority: High";
+        description = "This issue is prioritized as high";
+        color = colors.orange;
+      };
+      medium = {
+        name = ":star2: Priority: Medium";
+        description = "This issue is prioritized as medium";
+        color = colors.yellow;
+      };
+      low = {
+        name = ":low_brightness: Priority: Low";
+        description = "This issue is prioritized as low";
+        color = colors.green;
+      };
+    };
+    effort = {
+      "1" = {
+        name = ":muscle: Effort: 1";
+        description = "This issue is of low complexity or very well understood";
+        color = colors.green;
+      };
+      "2" = {
+        name = ":muscle: Effort: 3";
+        description = "This issue is of medium complexity or only partly well understood";
+        color = colors.yellow;
+      };
+      "5" = {
+        name = ":muscle: Effort: 5";
+        description = "This issue is of high complexity or just not yet well understood";
+        color = colors.red;
+      };
+    };
+  };
+
+  l = builtins;
+in {
+  labels =
+    []
+    ++ (l.attrValues labels.statuses)
+    ++ (l.attrValues labels.types)
+    ++ (l.attrValues labels.priorities)
+    ++ (l.attrValues labels.effort);
+}

--- a/src/data/configs/githubsettings.nix
+++ b/src/data/configs/githubsettings.nix
@@ -115,10 +115,12 @@ let
 
   l = builtins;
 in {
-  labels =
-    []
-    ++ (l.attrValues labels.statuses)
-    ++ (l.attrValues labels.types)
-    ++ (l.attrValues labels.priorities)
-    ++ (l.attrValues labels.effort);
+  data = {
+    labels =
+      []
+      ++ (l.attrValues labels.statuses)
+      ++ (l.attrValues labels.types)
+      ++ (l.attrValues labels.priorities)
+      ++ (l.attrValues labels.effort);
+  };
 }

--- a/src/data/configs/lefthook.nix
+++ b/src/data/configs/lefthook.nix
@@ -1,0 +1,21 @@
+{
+  commit-msg = {
+    commands = {
+      conform = {
+        # allow WIP, fixup!/squash! commits locally
+        run = ''
+          [[ "$(head -n 1 {1})" =~ ^WIP(:.*)?$|^wip(:.*)?$|fixup\!.*|squash\!.* ]] ||
+          conform enforce --commit-msg-file {1}'';
+        skip = ["merge" "rebase"];
+      };
+    };
+  };
+  pre-commit = {
+    commands = {
+      treefmt = {
+        run = "treefmt --fail-on-change {staged_files}";
+        skip = ["merge" "rebase"];
+      };
+    };
+  };
+}

--- a/src/data/configs/lefthook.nix
+++ b/src/data/configs/lefthook.nix
@@ -1,20 +1,22 @@
 {
-  commit-msg = {
-    commands = {
-      conform = {
-        # allow WIP, fixup!/squash! commits locally
-        run = ''
-          [[ "$(head -n 1 {1})" =~ ^WIP(:.*)?$|^wip(:.*)?$|fixup\!.*|squash\!.* ]] ||
-          conform enforce --commit-msg-file {1}'';
-        skip = ["merge" "rebase"];
+  data = {
+    commit-msg = {
+      commands = {
+        conform = {
+          # allow WIP, fixup!/squash! commits locally
+          run = ''
+            [[ "$(head -n 1 {1})" =~ ^WIP(:.*)?$|^wip(:.*)?$|fixup\!.*|squash\!.* ]] ||
+            conform enforce --commit-msg-file {1}'';
+          skip = ["merge" "rebase"];
+        };
       };
     };
-  };
-  pre-commit = {
-    commands = {
-      treefmt = {
-        run = "treefmt --fail-on-change {staged_files}";
-        skip = ["merge" "rebase"];
+    pre-commit = {
+      commands = {
+        treefmt = {
+          run = "treefmt --fail-on-change {staged_files}";
+          skip = ["merge" "rebase"];
+        };
       };
     };
   };

--- a/src/data/configs/mdbook.nix
+++ b/src/data/configs/mdbook.nix
@@ -1,15 +1,29 @@
-{
-  book = {
-    language = "en";
-    multilingual = false;
-    src = "docs";
-    title = "Documentation";
-  };
-  build = {
-    build-dir = "docs/book";
-  };
-  preprocessor.paisano-preprocessor = {
-    before = ["links"];
-    registry = ".#__std.init";
+let
+  inherit (inputs) nixpkgs;
+  inherit (inputs.mdbook-paisano-preprocessor.app.package) mdbook-paisano-preprocessor;
+in {
+  hook.mode = "copy"; # let CI pick it up outside of devshell
+  packages = [
+    nixpkgs.alejandra
+    nixpkgs.nodePackages.prettier
+    nixpkgs.nodePackages.prettier-plugin-toml
+    nixpkgs.shfmt
+    mdbook-paisano-preprocessor
+  ];
+
+  data = {
+    book = {
+      language = "en";
+      multilingual = false;
+      src = "docs";
+      title = "Documentation";
+    };
+    build = {
+      build-dir = "docs/book";
+    };
+    preprocessor.paisano-preprocessor = {
+      before = ["links"];
+      registry = ".#__std.init";
+    };
   };
 }

--- a/src/data/configs/mdbook.nix
+++ b/src/data/configs/mdbook.nix
@@ -1,0 +1,15 @@
+{
+  book = {
+    language = "en";
+    multilingual = false;
+    src = "docs";
+    title = "Documentation";
+  };
+  build = {
+    build-dir = "docs/book";
+  };
+  preprocessor.paisano-preprocessor = {
+    before = ["links"];
+    registry = ".#__std.init";
+  };
+}

--- a/src/data/configs/treefmt.nix
+++ b/src/data/configs/treefmt.nix
@@ -1,0 +1,30 @@
+{prettier-plugin-toml}: {
+  formatter = {
+    nix = {
+      command = "alejandra";
+      includes = ["*.nix"];
+    };
+    prettier = {
+      command = "prettier";
+      options = ["--plugin" "${prettier-plugin-toml}/lib/node_modules/prettier-plugin-toml/lib/api.js" "--write"];
+      includes = [
+        "*.css"
+        "*.html"
+        "*.js"
+        "*.json"
+        "*.jsx"
+        "*.md"
+        "*.mdx"
+        "*.scss"
+        "*.ts"
+        "*.yaml"
+        "*.toml"
+      ];
+    };
+    shell = {
+      command = "shfmt";
+      options = ["-i" "2" "-s" "-w"];
+      includes = ["*.sh"];
+    };
+  };
+}

--- a/src/data/configs/treefmt.nix
+++ b/src/data/configs/treefmt.nix
@@ -1,30 +1,42 @@
-{prettier-plugin-toml}: {
-  formatter = {
-    nix = {
-      command = "alejandra";
-      includes = ["*.nix"];
-    };
-    prettier = {
-      command = "prettier";
-      options = ["--plugin" "${prettier-plugin-toml}/lib/node_modules/prettier-plugin-toml/lib/api.js" "--write"];
-      includes = [
-        "*.css"
-        "*.html"
-        "*.js"
-        "*.json"
-        "*.jsx"
-        "*.md"
-        "*.mdx"
-        "*.scss"
-        "*.ts"
-        "*.yaml"
-        "*.toml"
-      ];
-    };
-    shell = {
-      command = "shfmt";
-      options = ["-i" "2" "-s" "-w"];
-      includes = ["*.sh"];
+let
+  inherit (inputs) nixpkgs;
+  inherit (inputs.nixpkgs) nodePackages;
+in {
+  packages = [
+    nixpkgs.alejandra
+    nixpkgs.nodePackages.prettier
+    nixpkgs.nodePackages.prettier-plugin-toml
+    nixpkgs.shfmt
+  ];
+
+  data = {
+    formatter = {
+      nix = {
+        command = "alejandra";
+        includes = ["*.nix"];
+      };
+      prettier = {
+        command = "prettier";
+        options = ["--plugin" "${nodePackages.prettier-plugin-toml}/lib/node_modules/prettier-plugin-toml/lib/api.js" "--write"];
+        includes = [
+          "*.css"
+          "*.html"
+          "*.js"
+          "*.json"
+          "*.jsx"
+          "*.md"
+          "*.mdx"
+          "*.scss"
+          "*.ts"
+          "*.yaml"
+          "*.toml"
+        ];
+      };
+      shell = {
+        command = "shfmt";
+        options = ["-i" "2" "-s" "-w"];
+        includes = ["*.sh"];
+      };
     };
   };
 }

--- a/src/data/flake.lock
+++ b/src/data/flake.lock
@@ -30,38 +30,45 @@
         "type": "github"
       }
     },
-    "devshell": {
+    "crane": {
       "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
         "nixpkgs": [
+          "mdbook-paisano-preprocessor",
           "nixpkgs"
         ],
-        "systems": "systems"
+        "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1687173957,
-        "narHash": "sha256-GOds2bAQcZ94fb9/Nl/aM+r+0wGSi4EKYuZYR8Dw4R8=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "2cf83bb31720fcc29a999aee28d6da101173e66a",
+        "lastModified": 1676162383,
+        "narHash": "sha256-krUCKdz7ebHlFYm/A7IbKDnj2ZmMMm3yIEQcooqm7+E=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "6fb400ec631b22ccdbc7090b38207f7fb5cfb5f2",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "devshell",
+        "owner": "ipetkov",
+        "repo": "crane",
         "type": "github"
       }
     },
     "dmerge": {
       "inputs": {
         "haumea": [
+          "mdbook-paisano-preprocessor",
           "std",
           "haumea"
         ],
         "nixlib": [
+          "mdbook-paisano-preprocessor",
           "std",
-          "lib"
+          "haumea",
+          "nixpkgs"
         ],
         "yants": [
+          "mdbook-paisano-preprocessor",
           "std",
           "yants"
         ]
@@ -81,28 +88,48 @@
         "type": "github"
       }
     },
-    "flake-utils": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "lastModified": 1677306201,
+        "narHash": "sha256-VZ9x7qdTosFvVsrpgFHrtYfT6PU3yMIs7NRYn9ELapI=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "0923f0c162f65ae40261ec940406049726cfeab4",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "nix-community",
+        "repo": "fenix",
         "type": "github"
       }
     },
-    "flake-utils_2": {
+    "flake-compat": {
+      "flake": false,
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -133,8 +160,10 @@
     "incl": {
       "inputs": {
         "nixlib": [
+          "mdbook-paisano-preprocessor",
           "std",
-          "lib"
+          "haumea",
+          "nixpkgs"
         ]
       },
       "locked": {
@@ -151,101 +180,43 @@
         "type": "github"
       }
     },
-    "lib": {
-      "locked": {
-        "lastModified": 1694306727,
-        "narHash": "sha256-26fkTOJOI65NOTNKFvtcJF9mzzf/kK9swHzfYt1Dl6Q=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "c30b6a84c0b84ec7aecbe74466033facc9ed103f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "n2c": {
+    "mdbook-paisano-preprocessor": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "crane": "crane",
+        "devshell": [],
+        "fenix": "fenix",
+        "nixago": [],
         "nixpkgs": [
           "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1685771919,
-        "narHash": "sha256-3lVKWrhNXjHJB6QkZ2SJaOs4X/mmYXtY6ovPVpDMOHc=",
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "rev": "95e2220911874064b5d809f8d35f7835184c4ddf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "type": "github"
-      }
-    },
-    "namaka": {
-      "inputs": {
-        "haumea": [
-          "std",
-          "haumea"
         ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "std": "std"
       },
       "locked": {
-        "lastModified": 1685739139,
-        "narHash": "sha256-CLGEW11Fo1v4vj0XSqiyW1EbhRZFO7dkgM43eKwItrk=",
-        "owner": "nix-community",
-        "repo": "namaka",
-        "rev": "d9a2cc83c1d0f68bd613f1fc909d0ef2cfffcf2e",
+        "lastModified": 1687483084,
+        "narHash": "sha256-T5yqwQoFipncAa1LGZlfKKCywGUjkUnSnGZ6e8UwDAs=",
+        "owner": "paisano-nix",
+        "repo": "mdbook-paisano-preprocessor",
+        "rev": "a6bd702a9cc93fc46f6aeb67aacddeecb307c245",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
-        "ref": "v0.2.0",
-        "repo": "namaka",
-        "type": "github"
-      }
-    },
-    "nixago": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixago-exts": [],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1687381756,
-        "narHash": "sha256-IUMIlYfrvj7Yli4H2vvyig8HEPpfCeMaE6+kBGPzFyk=",
-        "owner": "nix-community",
-        "repo": "nixago",
-        "rev": "dacceb10cace103b3e66552ec9719fa0d33c0dc9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixago",
+        "owner": "paisano-nix",
+        "repo": "mdbook-paisano-preprocessor",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687274257,
-        "narHash": "sha256-TutzPriQcZ8FghDhEolnHcYU2oHIG5XWF+/SUBNnAOE=",
+        "lastModified": 1677063315,
+        "narHash": "sha256-qiB4ajTeAOVnVSAwCNEEkoybrAlA+cpeiBxLobHndE8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2c9ecd1f0400076a4d6b2193ad468ff0a7e7fdc5",
+        "rev": "988cc958c57ce4350ec248d2d53087777f9e1949",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -262,6 +233,22 @@
       "original": {
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1694669921,
+        "narHash": "sha256-6ESpJ6FsftHV96JO/zn6je07tyV2dlLR7SdLsmkegTY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f2ea252d23ebc9a5336bf6a61e0644921f64e67c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -284,21 +271,23 @@
       "inputs": {
         "call-flake": "call-flake",
         "nixpkgs": [
+          "mdbook-paisano-preprocessor",
           "std",
           "nixpkgs"
         ],
         "nosys": "nosys",
         "yants": [
+          "mdbook-paisano-preprocessor",
           "std",
           "yants"
         ]
       },
       "locked": {
-        "lastModified": 1693982790,
-        "narHash": "sha256-WTZYlqGUjzzz/PSzcvjEZz2kkwYSXObjeQVrFBaqa2Y=",
+        "lastModified": 1687475968,
+        "narHash": "sha256-tFrPoD24Ph6VZjgmL3J4ICDWY6W/DnnHyupWeAL3Lw8=",
         "owner": "paisano-nix",
         "repo": "core",
-        "rev": "3e897a19418361ece34841105122ed4f9379ca96",
+        "rev": "9954e48e1ebc74a698b9d4ac02aee85514fc0237",
         "type": "github"
       },
       "original": {
@@ -310,98 +299,130 @@
     "paisano-tui": {
       "flake": false,
       "locked": {
-        "lastModified": 1694014205,
-        "narHash": "sha256-u0+T6vMznzfjDMUd01ZXQsrQPMEhMjrQwUPTFsPBR1k=",
+        "lastModified": 1681847764,
+        "narHash": "sha256-mdd7PJW1BZvxy0cIKsPfAO+ohVl/V7heE5ZTAHzTdv8=",
         "owner": "paisano-nix",
         "repo": "tui",
-        "rev": "587ab9fd07bd969d59df73bfe527b5f8a4e752d1",
+        "rev": "3096bad91cae73ab8ab3367d31f8a143d248a244",
         "type": "github"
       },
       "original": {
         "owner": "paisano-nix",
-        "ref": "0.2.0",
+        "ref": "0.1.1",
         "repo": "tui",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "devshell": "devshell",
-        "n2c": "n2c",
-        "namaka": "namaka",
-        "nixago": "nixago",
-        "nixpkgs": "nixpkgs",
-        "std": "std"
+        "mdbook-paisano-preprocessor": "mdbook-paisano-preprocessor",
+        "nixpkgs": "nixpkgs_3"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1677221702,
+        "narHash": "sha256-1M+58rC4eTCWNmmX0hQVZP20t3tfYNunl9D/PrGUyGE=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "f5401f620699b26ed9d47a1d2e838143a18dbe3b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "mdbook-paisano-preprocessor",
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "mdbook-paisano-preprocessor",
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1675391458,
+        "narHash": "sha256-ukDKZw922BnK5ohL9LhwtaDAdCsJL7L6ScNEyF1lO9w=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "383a4acfd11d778d5c2efcf28376cbd845eeaedf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "std": {
       "inputs": {
         "arion": [
+          "mdbook-paisano-preprocessor",
           "std",
           "blank"
         ],
         "blank": "blank",
         "devshell": [
+          "mdbook-paisano-preprocessor",
           "devshell"
         ],
         "dmerge": "dmerge",
         "haumea": "haumea",
         "incl": "incl",
-        "lib": "lib",
         "makes": [
+          "mdbook-paisano-preprocessor",
           "std",
           "blank"
         ],
         "microvm": [
+          "mdbook-paisano-preprocessor",
           "std",
           "blank"
         ],
         "n2c": [
-          "n2c"
+          "mdbook-paisano-preprocessor",
+          "std",
+          "blank"
         ],
         "nixago": [
+          "mdbook-paisano-preprocessor",
           "nixago"
         ],
         "nixpkgs": [
+          "mdbook-paisano-preprocessor",
           "nixpkgs"
         ],
         "paisano": "paisano",
         "paisano-tui": "paisano-tui",
-        "terranix": [
-          "std",
-          "blank"
-        ],
         "yants": "yants"
       },
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-wu7liUNT+cf9jIYgoPuhYpgR0KYK4bBEe1FAvI0o2Pk=",
-        "path": "/nix/store/pvbsxf557822wmdwpgmrilyi7wd7504a-source",
-        "type": "path"
-      },
-      "original": {
-        "path": "/nix/store/pvbsxf557822wmdwpgmrilyi7wd7504a-source",
-        "type": "path"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "lastModified": 1687482460,
+        "narHash": "sha256-KSut2GPMR//LJ62cMpHk+b8AHlDHWaSHTxCABzLY2yM=",
+        "owner": "divnix",
+        "repo": "std",
+        "rev": "1dfd574de0d2e3011d8df7ade3a3f2748b701a6d",
         "type": "github"
       },
       "original": {
-        "owner": "nix-systems",
-        "repo": "default",
+        "owner": "divnix",
+        "repo": "std",
         "type": "github"
       }
     },
     "yants": {
       "inputs": {
         "nixpkgs": [
+          "mdbook-paisano-preprocessor",
           "std",
           "haumea",
           "nixpkgs"

--- a/src/data/flake.nix
+++ b/src/data/flake.nix
@@ -1,10 +1,10 @@
 {
   inputs = {
     # injected (private) inputs
-    paisano-mdbook-preprocessor.url = "github:paisano-nix/mdbook-paisano-preprocessor";
-    paisano-mdbook-preprocessor.inputs.nixpkgs.follows = "nixpkgs";
-    paisano-mdbook-preprocessor.inputs.nixago.follows = "";
-    paisano-mdbook-preprocessor.inputs.devshell.follows = "";
+    mdbook-paisano-preprocessor.url = "github:paisano-nix/mdbook-paisano-preprocessor";
+    mdbook-paisano-preprocessor.inputs.nixpkgs.follows = "nixpkgs";
+    mdbook-paisano-preprocessor.inputs.nixago.follows = "";
+    mdbook-paisano-preprocessor.inputs.devshell.follows = "";
 
     # injected inputs to override std's defaults
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable-small";

--- a/src/data/flake.nix
+++ b/src/data/flake.nix
@@ -1,0 +1,13 @@
+{
+  inputs = {
+    # injected (private) inputs
+    paisano-mdbook-preprocessor.url = "github:paisano-nix/mdbook-paisano-preprocessor";
+    paisano-mdbook-preprocessor.inputs.nixpkgs.follows = "nixpkgs";
+    paisano-mdbook-preprocessor.inputs.nixago.follows = "";
+    paisano-mdbook-preprocessor.inputs.devshell.follows = "";
+
+    # injected inputs to override std's defaults
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable-small";
+  };
+  outputs = i: i;
+}

--- a/src/lib/cfg.nix
+++ b/src/lib/cfg.nix
@@ -10,4 +10,5 @@
   mdbook = import ./cfg/mdbook.nix {inherit inputs cell;};
   treefmt = import ./cfg/treefmt.nix {inherit inputs cell;};
   githubsettings = import ./cfg/githubsettings.nix {inherit inputs cell;};
+  cog = import ./cfg/cog.nix {inherit inputs cell;};
 }

--- a/src/lib/cfg/cog.nix
+++ b/src/lib/cfg/cog.nix
@@ -1,0 +1,10 @@
+{
+  inputs,
+  cell,
+}: let
+  inherit (inputs) nixpkgs;
+in {
+  data = {};
+  output = "cog.toml";
+  commands = [{package = nixpkgs.cocogitto;}];
+}

--- a/src/local/configs.nix
+++ b/src/local/configs.nix
@@ -3,86 +3,20 @@
   cell,
 }: let
   inherit (inputs) nixpkgs;
-  inherit (inputs.std) std presets;
-  l = nixpkgs.lib // builtins;
+  inherit (inputs.std.data) configs;
+  inherit (inputs.std.lib.dev) mkNixago;
 in {
-  cog = {
-    output = "cog.toml";
-    commands = [{package = nixpkgs.cocogitto;}];
-    data = {
-      tag_prefix = "v";
-      branch_whitelist = ["main" "release/**"];
-      ignore_merge_commits = true;
-      pre_bump_hooks = [
-        "echo {{version}} > ./VERSION"
-        ''
-          branch="$(echo "release/{{version}}" | sed 's/\.[^.]*$//')"
-          if [ `git rev-parse --verify $branch 2>/dev/null` ]
-          then
-            git switch -m "$branch" || exit 1
-            git merge main
-          else
-            git switch -c "$branch" || exit 1
-          fi
-        ''
-      ];
-      post_bump_hooks = [
-        ''
-          branch="$(echo "release/{{version}}" | sed 's/\.[^.]*$//')"
-          git push --set-upstream origin "$branch"
-          git push origin v{{version}}
-
-          git switch main
-          git merge "$branch" --no-commit --no-ff
-          echo {{version+minor-dev}} > ./VERSION
-          git add VERSION
-          git commit -m "chore: sync with release"
-          git push origin main
-        ''
-        "cog -q changelog --at v{{version}}"
-      ];
-      changelog = {
-        path = "CHANGELOG.md";
-        template = "remote";
-        remote = "github.com";
-        repository = "std";
-        owner = "divnix";
-      };
+  cog = (mkNixago configs.cog) {
+    data.changelog = {
+      remote = "github.com";
+      repository = "std";
+      owner = "divnix";
     };
   };
-  treefmt = {
+  treefmt = (mkNixago configs.treefmt) {
     data = {
-      global.excludes = [
-        "cells/presets/templates/**"
-      ];
+      global.excludes = ["src/std/templates/**"];
       formatter = {
-        nix = {
-          command = "alejandra";
-          includes = ["*.nix"];
-        };
-        prettier = {
-          command = "prettier";
-          options = ["--plugin" "prettier-plugin-toml" "--write"];
-          includes = [
-            "*.css"
-            "*.html"
-            "*.js"
-            "*.json"
-            "*.jsx"
-            "*.md"
-            "*.mdx"
-            "*.scss"
-            "*.ts"
-            "*.yaml"
-            "*.toml"
-          ];
-        };
-        shell = {
-          command = "shfmt";
-          options = ["-i" "2" "-s" "-w"];
-          includes = ["*.sh"];
-        };
-
         go = {
           command = "gofmt";
           options = ["-w"];
@@ -93,51 +27,10 @@ in {
         };
       };
     };
-    packages = [
-      nixpkgs.alejandra
-      nixpkgs.nodePackages.prettier
-      nixpkgs.nodePackages.prettier-plugin-toml
-      nixpkgs.shfmt
-      nixpkgs.go
-    ];
-    devshell.startup.prettier-plugin-toml = l.stringsWithDeps.noDepEntry ''
-      export NODE_PATH=${nixpkgs.nodePackages.prettier-plugin-toml}/lib/node_modules:''${NODE_PATH-}
-    '';
+    packages = [nixpkgs.go];
   };
-  editorconfig = {
-    hook.mode = "copy"; # already useful before entering the devshell
+  editorconfig = (mkNixago configs.editorconfig) {
     data = {
-      root = true;
-
-      "*" = {
-        end_of_line = "lf";
-        insert_final_newline = true;
-        trim_trailing_whitespace = true;
-        charset = "utf-8";
-        indent_style = "space";
-        indent_size = 2;
-      };
-
-      "*.{diff,patch}" = {
-        end_of_line = "unset";
-        insert_final_newline = "unset";
-        trim_trailing_whitespace = "unset";
-        indent_size = "unset";
-      };
-
-      "*.md" = {
-        max_line_length = "off";
-        trim_trailing_whitespace = false;
-      };
-      "{LICENSES/**,LICENSE}" = {
-        end_of_line = "unset";
-        insert_final_newline = "unset";
-        trim_trailing_whitespace = "unset";
-        charset = "unset";
-        indent_style = "unset";
-        indent_size = "unset";
-      };
-
       "*.xcf" = {
         charset = "unset";
         end_of_line = "unset";
@@ -152,187 +45,53 @@ in {
       };
     };
   };
-  mdbook = {
-    output = "docs/book.toml";
+  mdbook = (mkNixago configs.mdbook) {
     data = {
-      book = {
-        language = "en";
-        multilingual = false;
-        title = "The Standard Documentation";
-        src = ".";
-      };
-      build = {
-        build-dir = "book";
-      };
-      preprocessor = {
-        paisano-preprocessor = {
-          before = ["links"];
-          registry = "..#__std.init";
-          multi = [
-            {
-              chapter = "Cell: lib";
-              cell = "lib";
-            }
-            {
-              chapter = "Cell: std";
-              cell = "std";
-            }
-          ];
-        };
-      };
-      output.html = {
-        additional-js = ["theme/pagetoc.js"];
-        additional-css = ["theme/pagetoc.css"];
-      };
-    };
-    packages = [inputs.paisano-mdbook-preprocessor.packages.default];
-    hook.mode = "copy"; # let CI pick it up outside of devshell
-  };
-  githubsettings = {
-    data = let
-      colors = {
-        black = "#000000";
-        blue = "#1565C0";
-        lightBlue = "#64B5F6";
-        green = "#4CAF50";
-        grey = "#A6A6A6";
-        lightGreen = "#81C784";
-        gold = "#FDD835";
-        orange = "#FB8C00";
-        purple = "#AB47BC";
-        red = "#F44336";
-        yellow = "#FFEE58";
-      };
-      labels = {
-        statuses = {
-          abandoned = {
-            name = ":running: Status: Abdandoned";
-            description = "This issue has been abdandoned";
-            color = colors.black;
-          };
-          accepted = {
-            name = ":ok: Status: Accepted";
-            description = "This issue has been accepted";
-            color = colors.green;
-          };
-          blocked = {
-            name = ":x: Status: Blocked";
-            description = "This issue is in a blocking state";
-            color = colors.red;
-          };
-          inProgress = {
-            name = ":construction: Status: In Progress";
-            description = "This issue is actively being worked on";
-            color = colors.grey;
-          };
-          onHold = {
-            name = ":golf: Status: On Hold";
-            description = "This issue is not currently being worked on";
-            color = colors.red;
-          };
-          reviewNeeded = {
-            name = ":eyes: Status: Review Needed";
-            description = "This issue is pending a review";
-            color = colors.gold;
-          };
-        };
-        types = {
-          bug = {
-            name = ":bug: Type: Bug";
-            description = "This issue targets a bug";
-            color = colors.red;
-          };
-          story = {
-            name = ":scroll: Type: Story";
-            description = "This issue targets a new feature through a story";
-            color = colors.lightBlue;
-          };
-          maintenance = {
-            name = ":wrench: Type: Maintenance";
-            description = "This issue targets general maintenance";
-            color = colors.orange;
-          };
-          question = {
-            name = ":grey_question: Type: Question";
-            description = "This issue contains a question";
-            color = colors.purple;
-          };
-          security = {
-            name = ":cop: Type: Security";
-            description = "This issue targets a security vulnerability";
-            color = colors.red;
-          };
-        };
-        priorities = {
-          critical = {
-            name = ":boom: Priority: Critical";
-            description = "This issue is prioritized as critical";
-            color = colors.red;
-          };
-          high = {
-            name = ":fire: Priority: High";
-            description = "This issue is prioritized as high";
-            color = colors.orange;
-          };
-          medium = {
-            name = ":star2: Priority: Medium";
-            description = "This issue is prioritized as medium";
-            color = colors.yellow;
-          };
-          low = {
-            name = ":low_brightness: Priority: Low";
-            description = "This issue is prioritized as low";
-            color = colors.green;
-          };
-        };
-        effort = {
-          "1" = {
-            name = ":muscle: Effort: 1";
-            description = "This issue is of low complexity or very well understood";
-            color = colors.green;
-          };
-          "2" = {
-            name = ":muscle: Effort: 3";
-            description = "This issue is of medium complexity or only partly well understood";
-            color = colors.yellow;
-          };
-          "5" = {
-            name = ":muscle: Effort: 5";
-            description = "This issue is of high complexity or just not yet well understood";
-            color = colors.red;
-          };
-        };
-      };
-
-      l = builtins;
-    in
-      {
-        labels =
-          []
-          ++ (l.attrValues labels.statuses)
-          ++ (l.attrValues labels.types)
-          ++ (l.attrValues labels.priorities)
-          ++ (l.attrValues labels.effort);
-      }
-      // {
-        repository = {
-          name = "std";
-          homepage = "https://std.divnix.com";
-          description = "A DevOps framework for the SDLC with the power of Nix and Flakes. Good for keeping deadlines!";
-          topics = "nix, nix-flakes, devops, sdlc";
-          default_branch = "main";
-          allow_squash_merge = true;
-          allow_merge_commit = false;
-          allow_rebase_merge = true;
-          delete_branch_on_merge = true;
-        };
-        milestones = [
+      book.title = "The Standard Documentation";
+      preprocessor.paisano-preprocessor = {
+        multi = [
           {
-            title = "Release v1";
-            description = ":dart:";
-            state = "open";
+            chapter = "Cell: lib";
+            cell = "lib";
+          }
+          {
+            chapter = "Cell: std";
+            cell = "std";
           }
         ];
       };
+      output.html = {
+        additional-js = ["docs/theme/pagetoc.js"];
+        additional-css = ["docs/theme/pagetoc.css"];
+      };
+    };
   };
+
+  githubsettings = (mkNixago configs.githubsettings) {
+    data = {
+      repository = {
+        name = "std";
+        homepage = "https://std.divnix.com";
+        description = "A DevOps framework for the SDLC with the power of Nix and Flakes. Good for keeping deadlines!";
+        topics = "nix, nix-flakes, devops, sdlc";
+        default_branch = "main";
+        allow_squash_merge = true;
+        allow_merge_commit = false;
+        allow_rebase_merge = true;
+        delete_branch_on_merge = true;
+      };
+      milestones = [
+        {
+          title = "Release v1";
+          description = ":dart:";
+          state = "open";
+        }
+      ];
+    };
+  };
+  adrgen = (mkNixago configs.adrgen) {};
+  conform = (mkNixago configs.conform) {
+    data = {inherit (inputs) cells;};
+  };
+  lefthook = (mkNixago configs.lefthook) {};
 }

--- a/src/local/flake.lock
+++ b/src/local/flake.lock
@@ -83,8 +83,7 @@
         ],
         "nixlib": [
           "std",
-          "haumea",
-          "nixpkgs"
+          "lib"
         ],
         "yants": [
           "std",
@@ -209,8 +208,7 @@
       "inputs": {
         "nixlib": [
           "std",
-          "haumea",
-          "nixpkgs"
+          "lib"
         ]
       },
       "locked": {
@@ -224,6 +222,21 @@
       "original": {
         "owner": "divnix",
         "repo": "incl",
+        "type": "github"
+      }
+    },
+    "lib": {
+      "locked": {
+        "lastModified": 1694306727,
+        "narHash": "sha256-26fkTOJOI65NOTNKFvtcJF9mzzf/kK9swHzfYt1Dl6Q=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "c30b6a84c0b84ec7aecbe74466033facc9ed103f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
         "type": "github"
       }
     },
@@ -494,6 +507,7 @@
         "dmerge": "dmerge",
         "haumea": "haumea",
         "incl": "incl",
+        "lib": "lib",
         "makes": [
           "std",
           "blank"
@@ -521,12 +535,12 @@
       },
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-tpDF+OONTimxQgHv3CEBGxXmhw/K8IxsQfaaQw2+k8o=",
-        "path": "/nix/store/k5844rfql5x6ya52912csr0dl6bhf6q5-source",
+        "narHash": "sha256-Od+xml4wB5sbfxj2pqOsX4ubH9VruSWzci8DnUh83Zc=",
+        "path": "/nix/store/hkm632gfhndfipasjx573n5k9yj8j925-source",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/k5844rfql5x6ya52912csr0dl6bhf6q5-source",
+        "path": "/nix/store/hkm632gfhndfipasjx573n5k9yj8j925-source",
         "type": "path"
       }
     },

--- a/src/local/flake.nix
+++ b/src/local/flake.nix
@@ -1,9 +1,6 @@
 {
   inputs = {
     # injected (private) inputs
-    paisano-mdbook-preprocessor.url = "github:paisano-nix/mdbook-paisano-preprocessor";
-    paisano-mdbook-preprocessor.inputs.std.follows = "std";
-    paisano-mdbook-preprocessor.inputs.nixpkgs.follows = "nixpkgs";
     namaka.url = "github:nix-community/namaka/v0.2.0";
     namaka.inputs.haumea.follows = "std/haumea";
     namaka.inputs.nixpkgs.follows = "nixpkgs";

--- a/src/local/shells.nix
+++ b/src/local/shells.nix
@@ -2,25 +2,23 @@
   inputs,
   cell,
 }: let
-  l = nixpkgs.lib // builtins;
   inherit (inputs) nixpkgs namaka;
-  inherit (inputs.std) std lib;
+  inherit (inputs.nixpkgs.lib) mapAttrs optionals;
+  inherit (inputs.std) std;
+  inherit (inputs.std.lib.dev) mkShell;
+  inherit (cell) configs;
 in
-  l.mapAttrs (_: lib.dev.mkShell) rec {
+  mapAttrs (_: mkShell) rec {
     default = {...}: {
       name = "Standard";
       nixago = [
-        ((lib.dev.mkNixago lib.cfg.conform)
-          {data = {inherit (inputs) cells;};})
-        ((lib.dev.mkNixago lib.cfg.treefmt)
-          cell.configs.treefmt)
-        ((lib.dev.mkNixago lib.cfg.editorconfig)
-          cell.configs.editorconfig)
-        ((lib.dev.mkNixago lib.cfg.githubsettings)
-          cell.configs.githubsettings)
-        (lib.dev.mkNixago lib.cfg.lefthook)
-        (lib.dev.mkNixago lib.cfg.adrgen)
-        (lib.dev.mkNixago cell.configs.cog)
+        configs.conform
+        configs.treefmt
+        configs.editorconfig
+        configs.githubsettings
+        configs.lefthook
+        configs.adrgen
+        configs.cog
       ];
       commands =
         [
@@ -50,7 +48,7 @@ in
             category = "nix-testing";
           }
         ]
-        ++ l.optionals nixpkgs.stdenv.isLinux [
+        ++ optionals nixpkgs.stdenv.isLinux [
           {
             package = nixpkgs.golangci-lint;
             category = "cli-dev";
@@ -60,9 +58,6 @@ in
     };
 
     book = {...}: {
-      nixago = [
-        ((lib.dev.mkNixago lib.cfg.mdbook)
-          cell.configs.mdbook)
-      ];
+      nixago = [configs.mdbook];
     };
   }

--- a/src/tests/flake.lock
+++ b/src/tests/flake.lock
@@ -546,12 +546,12 @@
       },
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-f1KnRIsQwC46lbbyJW07N4KzYiwvTPSnZOTlGSjgN0w=",
-        "path": "/nix/store/ds26bw3zck02l14dj7s66kq1k95anbnn-source",
+        "narHash": "sha256-+T2Z0/wrY36VlYxrxpH6XOxueOhY01d328Xd8dK3JpM=",
+        "path": "/nix/store/khy89qylx627ldk11i0ndkijr94yyhv6-source",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/ds26bw3zck02l14dj7s66kq1k95anbnn-source",
+        "path": "/nix/store/khy89qylx627ldk11i0ndkijr94yyhv6-source",
         "type": "path"
       }
     },

--- a/src/tests/flake.lock
+++ b/src/tests/flake.lock
@@ -81,8 +81,7 @@
         ],
         "nixlib": [
           "std",
-          "haumea",
-          "nixpkgs"
+          "lib"
         ],
         "yants": [
           "std",
@@ -245,8 +244,7 @@
       "inputs": {
         "nixlib": [
           "std",
-          "haumea",
-          "nixpkgs"
+          "lib"
         ]
       },
       "locked": {
@@ -260,6 +258,21 @@
       "original": {
         "owner": "divnix",
         "repo": "incl",
+        "type": "github"
+      }
+    },
+    "lib": {
+      "locked": {
+        "lastModified": 1694306727,
+        "narHash": "sha256-26fkTOJOI65NOTNKFvtcJF9mzzf/kK9swHzfYt1Dl6Q=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "c30b6a84c0b84ec7aecbe74466033facc9ed103f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
         "type": "github"
       }
     },
@@ -507,6 +520,7 @@
         "dmerge": "dmerge",
         "haumea": "haumea",
         "incl": "incl",
+        "lib": "lib",
         "makes": [
           "makes"
         ],
@@ -532,12 +546,12 @@
       },
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-4wYgOTDYkjtu5zWm/fqMUslnXjVc2FmJSo5ZdFD1ttg=",
-        "path": "/nix/store/00zc25d5ydqf11gz9kfv8x7b6p7zkbsw-source",
+        "narHash": "sha256-f1KnRIsQwC46lbbyJW07N4KzYiwvTPSnZOTlGSjgN0w=",
+        "path": "/nix/store/ds26bw3zck02l14dj7s66kq1k95anbnn-source",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/00zc25d5ydqf11gz9kfv8x7b6p7zkbsw-source",
+        "path": "/nix/store/ds26bw3zck02l14dj7s66kq1k95anbnn-source",
         "type": "path"
       }
     },

--- a/tests/_snapshots/cells-lib-cfg
+++ b/tests/_snapshots/cells-lib-cfg
@@ -1,6 +1,7 @@
 #pretty
 {
   adrgen = <derivation adrgen.config.yml>;
+  cog = <derivation cog.toml>;
   conform = <derivation conform.yaml>;
   editorconfig = <derivation editorconfig>;
   githubsettings = <derivation settings.yml>;


### PR DESCRIPTION
- refactor: bring back config data sets
- refactor: use local config data sets
- refactor: normalize configs
- test: review and accept new lib.cfg snapshot

# Context

Previously, the nixago data collections where factored out in an attempt to be more crisp.

This attempt completely failed and it was just absolutely unergonomic to use `divnix/std-data-collection` whereas the stated aim of Standard is to reduce the setup time and get you up-and-running quickly.

# Solution

Incorporate the config data once again into the repository. Be opinionated on purpose. Get people up and running quickly.
