### PR TITLE
chore: ensure a single lib input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,7 +59,9 @@
     },
     "haumea": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "lib"
+        ]
       },
       "locked": {
         "lastModified": 1685133229,
@@ -112,21 +114,6 @@
       }
     },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1681001314,
-        "narHash": "sha256-5sDnCLdrKZqxLPK4KA8+f4A3YKO/u6ElpMILvX0g72c=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "367c0e1086a4eb4502b24d872cea2c7acdd557f4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
       "locked": {
         "lastModified": 1675940568,
         "narHash": "sha256-epG6pOT9V0kS+FUqd7R6/CWkgnZx2DMT5Veqo+y6G3c=",
@@ -224,7 +211,7 @@
         "nixago": [
           "blank"
         ],
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "paisano": "paisano",
         "paisano-tui": "paisano-tui",
         "terranix": [
@@ -236,8 +223,7 @@
     "yants": {
       "inputs": {
         "nixpkgs": [
-          "haumea",
-          "nixpkgs"
+          "lib"
         ]
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
   inputs.blank.url = "github:divnix/blank";
   inputs.yants = {
     url = "github:divnix/yants";
-    inputs.nixpkgs.follows = "haumea/nixpkgs";
+    inputs.nixpkgs.follows = "lib";
   };
   inputs.dmerge = {
     url = "github:divnix/dmerge/0.2.1";
@@ -29,6 +29,7 @@
   };
   inputs.haumea = {
     url = "github:nix-community/haumea/v0.2.2";
+    inputs.nixpkgs.follows = "lib";
   };
   inputs.incl = {
     url = "github:divnix/incl";


### PR DESCRIPTION
# Context

In https://github.com/divnix/std/pull/349 we semantically sepratated `lib` from `nixpkg$`, however we didn't catch all follows.

# Solution

- Finish the job
  - `yants` already used `nixpkgs.lib`
  - and so did `haumea`
