### PR TITLE
fix: cocogitto cli name in devshell menu

### DIFF
--- a/src/lib/cfg/cog.nix
+++ b/src/lib/cfg/cog.nix
@@ -3,5 +3,10 @@ let
 in {
   data = {};
   output = "cog.toml";
-  commands = [{package = nixpkgs.cocogitto;}];
+  commands = [
+    {
+      package = nixpkgs.cocogitto;
+      name = "cog";
+    }
+  ];
 }


### PR DESCRIPTION
# Context

Is:
```
  cocogitto     - A set of cli tools for the conventional commit and semver specifications
```

Want:
```
  cog           - A set of cli tools for the conventional commit and semver specifications
```

# Solution

- add the `name` attribute to the command option
