### PR TITLE
Set default for nixpkgsConfig in flake-parts module

### DIFF
--- a/src/std/fwlib/flakeModule.nix
+++ b/src/std/fwlib/flakeModule.nix
@@ -115,6 +115,7 @@ in
               nixpkgsConfig = mkOption {
                 description = "Nixpkgs configuration applied to `inputs.nixpkgs` (if that input exists).";
                 type = with lib.types; attrs;
+                default = {};
                 example = literalExpression ''
                   { allowUnfree = true; }
                 '';
@@ -171,9 +172,8 @@ in
             inherit inputs;
             inherit (config) systems;
             # access them explicitly to trigger a module system error if not defined
-            inherit (cfg.grow) cellsFrom cellBlocks;
-          }
-          // lib.optionalAttrs (opt.grow.type.getSubOptions opt.grow.loc).nixpkgsConfig.isDefined {inherit (cfg.grow) nixpkgsConfig;});
+            inherit (cfg.grow) cellsFrom cellBlocks nixpkgsConfig;
+          });
         picked = mapAttrs (_: v: pick grown v) cfg.pick;
         harvested = mapAttrs (_: v: harvest grown v) cfg.harvest;
         winnowed = zipAttrsWith (n: v: winnow (head v) grown (head (tail v))) [cfg.winnowIf cfg.winnow];


### PR DESCRIPTION
For divnix/std#235, `std.grow.nixpkgsConfig` was made optional. However (at least in my config), `nixpkgsConfig` is not defined when it's checked for, even if it's set. Instead, I think setting a default of `{ }` should work - as far as I can tell, that's ultimately what it defaults to in nixpkgs.