### PR TITLE
Fix kubectl arguments order

### DIFF
--- a/src/std/fwlib/blockTypes/kubectl.nix
+++ b/src/std/fwlib/blockTypes/kubectl.nix
@@ -127,8 +127,8 @@ in
           kubectl diff ${
           if usesKustomize
           then "--kustomize"
-          else "--filename --recursive"
-        } "$manifest_path";
+          else "--recursive --filename"
+        } "$manifest_path/";
         }
 
         # GitHub case
@@ -171,8 +171,8 @@ in
           kubectl diff --server-side=true --field-manager="std-action-$(whoami)" ${
           if usesKustomize
           then "--kustomize"
-          else "--filename --recursive"
-        } "$manifest_path";
+          else "--recursive --filename"
+        } "$manifest_path/";
 
           return $?;
         }
@@ -181,8 +181,8 @@ in
           kubectl apply --server-side=true --field-manager="std-action-$(whoami)" ${
           if usesKustomize
           then "--kustomize"
-          else "--filename --recursive"
-        } "$manifest_path";
+          else "--recursive --filename"
+        } "$manifest_path/";
         }
 
         diff


### PR DESCRIPTION
# Context
While running apply and diff through `std` cli,
`kubectl` will produce an unexpected args error.
# Solution
Put the filename arg after recursive,
so that it can be followed by a manifest path