### PR TITLE
Fix metadata labels of manifest

### DIFF
--- a/src/std/fwlib/blockTypes/kubectl.nix
+++ b/src/std/fwlib/blockTypes/kubectl.nix
@@ -57,6 +57,12 @@ in
               lib.flip lib.pipe [
                 # metadata
                 (
+                  manifest:
+                    if manifest ? metadata.labels && manifest.metadata.labels == null
+                    then lib.recursiveUpdate manifest {metadata.labels = {};}
+                    else manifest
+                )
+                (
                   amendIfExists ["metadata"]
                   {
                     metadata.labels."app.kubernetes.io/version" = checkedRev;


### PR DESCRIPTION
Greetings @blaggacao, found a bug while using the blocktype kubectl, below is the explaination
# Context
In yaml (manifest), `metadata.labels` can be `null`
e.g.
```yaml
metadata:
  labels:
```
or
```yaml
metadata:
  labels: null
```
instead of the standard
```yaml
metadata:
  labels: {}
```
Which cause the `dmerge` in `amendAlways` fails
```sh
       error:
       rigt-hand-side must be of the same type as left-hand-side
       at 'metadata.labels':
       - lhs: null @ undetectable posision
       - rhs: set @ /nix/store/z6hf8dcim8qdgs0nh6bvf52x0w2zzkpf-incl/std/fwlib/blockTypes/kubectl.nix:62:21
```
# Solution
Patch the edge case, with `manifest.metadata.labels = {};` before doing `dmerge` (now `lhs` will also be a set).