### PR TITLE
Use overlay for devshell

### DIFF
--- a/src/lib/dev/mkShell.nix
+++ b/src/lib/dev/mkShell.nix
@@ -4,6 +4,11 @@ let
   inherit (requireInput "devshell" "github:numtide/devshell" "std.lib.dev.mkShell") devshell nixago;
 
   l = inputs.nixpkgs.lib // builtins;
+
+  pkgs = import inputs.nixpkgs {
+    inherit (inputs.nixpkgs) system;
+    overlays = [inputs.devshell.overlays.default];
+  };
 in
   configuration: let
     nixagoModule = {
@@ -55,6 +60,6 @@ in
           };
       };
   in
-    devshell.legacyPackages.mkShell {
+    pkgs.devshell.mkShell {
       imports = [configuration nixagoModule];
     }


### PR DESCRIPTION
Greetings @blaggacao 
# Context
Two days ago, a PR was merged on devshell side removing `legacyPackages`
https://github.com/numtide/devshell/pull/289/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L13
lead to the follow error
```sh
error: attribute 'legacyPackages' missing

       at /nix/store/w36lpbbhyghaqdbzcnda35y27knsiblk-incl/lib/dev/mkShell.nix:58:5:

           57|   in
           58|     devshell.legacyPackages.mkShell {
             |     ^
           59|       imports = [configuration nixagoModule];
```
# Solution
Today, pkgs overlays still support by devshell, so we can switch to use it to fix this issue