### PR TITLE
feat/nvfetcher blocktype

### DIFF
--- a/src/std/fwlib/blockTypes/nvfetcher.nix
+++ b/src/std/fwlib/blockTypes/nvfetcher.nix
@@ -1,0 +1,47 @@
+{
+  root,
+  super,
+}:
+/*
+Use the nvfetcher Blocktype in order to instrucement sources
+with nvfetcher. See its docs for more details.
+
+Available actions:
+  - fetch
+*/
+let
+  inherit (root) mkCommand actions;
+  inherit (super) addSelectorFunctor;
+in
+  name: {
+    __functor = addSelectorFunctor;
+    inherit name;
+    type = "nvfetcher";
+    actions = {
+      currentSystem,
+      fragment,
+      fragmentRelPath,
+      target,
+      inputs,
+    }: let
+      pkgs = inputs.nixpkgs.${currentSystem};
+      inherit (pkgs) lib;
+      inherit (pkgs.stdenv) isLinux;
+    in [
+      (mkCommand currentSystem "fetch" "update source" [pkgs.nvfetcher] ''
+         targetname="$(basename ${fragmentRelPath})"
+         blockpath="$(dirname ${fragmentRelPath})"
+         cellpath="$(dirname "$blockpath")"
+         tmpfile="$(mktemp)"
+         updates="$PRJ_ROOT/${fragmentRelPath}.md"
+         nvfetcher \
+           --config "$PRJ_ROOT/$cellpath/nvfetcher.toml" \
+           --build-dir "$PRJ_ROOT/$blockpath" \
+           --changelog "$tmpfile" \
+           --filter "^$targetname$"
+
+        sed -i -e "s|^|- \`$(date --iso-8601=m)\` |" "$tmpfile"
+        cat "$tmpfile" >> "$updates"
+      '' {})
+    ];
+  }

--- a/tests/_snapshots/bt-blocktypes
+++ b/tests/_snapshots/bt-blocktypes
@@ -310,6 +310,17 @@
     name = "nomad";
     type = "nomadJobManifests";
   };
+  nvfetcher = {
+    actions = [
+      {
+        command = <derivation fetch>;
+        description = "update source";
+        name = "fetch";
+      }
+    ];
+    name = "nvfetcher";
+    type = "nvfetcher";
+  };
   pkgs = {
     cli = false;
     name = "pkgs";


### PR DESCRIPTION
- feat: add nvfetcher blocktype
- test: update snapshot with nvfetcher blocktype

# Context

Flake inputs don't store metadata, such as for example the url from which they where fetched.

There's no practical way \* to get that data unless the repository contains it in its files.

However, sometisem you need that metadata, for example to clone local compies of the sources
to work on them.

\* you could parse flake.nix manually with something like `(import <reporoot>/flake.nix).inputs`, in all theroy

Also, albeit solutions such as flakehub exist, flake inputs are notoriously bad at detecting new versions.

# Proposed Solution

Implement an [`nvfetcher`](https://github.com/berberman/nvfetcher) block type in order to:

- Manage app sources
- Manage updates
- Improve their version control
- Access source metadata within your nix code
