### PR TITLE
fix: lefthook: run directly instead of (default) complex script

### DIFF
--- a/src/data/configs/lefthook.nix
+++ b/src/data/configs/lefthook.nix
@@ -1,4 +1,7 @@
-{
+let
+  inherit (inputs) nixpkgs;
+  inherit (inputs.nixpkgs) lib;
+in {
   data = {
     commit-msg = {
       commands = {
@@ -6,7 +9,7 @@
           # allow WIP, fixup!/squash! commits locally
           run = ''
             [[ "$(head -n 1 {1})" =~ ^WIP(:.*)?$|^wip(:.*)?$|fixup\!.*|squash\!.* ]] ||
-            conform enforce --commit-msg-file {1}'';
+            ${lib.getExe nixpkgs.conform} enforce --commit-msg-file {1}'';
           skip = ["merge" "rebase"];
         };
       };
@@ -14,7 +17,7 @@
     pre-commit = {
       commands = {
         treefmt = {
-          run = "treefmt --fail-on-change {staged_files}";
+          run = "${lib.getExe nixpkgs.treefmt} --fail-on-change {staged_files}";
           skip = ["merge" "rebase"];
         };
       };

--- a/src/data/configs/treefmt.nix
+++ b/src/data/configs/treefmt.nix
@@ -1,6 +1,6 @@
 let
   inherit (inputs) nixpkgs;
-  inherit (inputs.nixpkgs) nodePackages;
+  inherit (inputs.nixpkgs) lib;
 in {
   packages = [
     nixpkgs.alejandra
@@ -12,12 +12,12 @@ in {
   data = {
     formatter = {
       nix = {
-        command = "alejandra";
+        command = lib.getExe nixpkgs.alejandra;
         includes = ["*.nix"];
       };
       prettier = {
-        command = "prettier";
-        options = ["--plugin" "${nodePackages.prettier-plugin-toml}/lib/node_modules/prettier-plugin-toml/lib/api.js" "--write"];
+        command = lib.getExe nixpkgs.nodePackages.prettier;
+        options = ["--plugin" "${nixpkgs.nodePackages.prettier-plugin-toml}/lib/node_modules/prettier-plugin-toml/lib/api.js" "--write"];
         includes = [
           "*.css"
           "*.html"
@@ -33,7 +33,7 @@ in {
         ];
       };
       shell = {
-        command = "shfmt";
+        command = lib.getExe nixpkgs.shfmt;
         options = ["-i" "2" "-s" "-w"];
         includes = ["*.sh"];
       };

--- a/src/lib/cfg/lefthook.nix
+++ b/src/lib/cfg/lefthook.nix
@@ -1,26 +1,35 @@
 let
   inherit (inputs) nixpkgs;
-  l = nixpkgs.lib // builtins;
-in {
-  data = {};
-  format = "yaml";
-  output = "lefthook.yml";
-  packages = [nixpkgs.lefthook];
-  hook.extra = d: let
-    # Add an extra hook for adding required stages whenever the file changes
-    skip_attrs = [
+  lib = nixpkgs.lib // builtins;
+
+  mkScript = stage:
+    nixpkgs.writeScript "lefthook-${stage}" ''
+      #!${nixpkgs.runtimeShell}
+      [ "$LEFTHOOK" == "0" ] || ${lib.getExe nixpkgs.lefthook} run "${stage}" "$@"
+    '';
+
+  toStagesConfig = config:
+    lib.removeAttrs config [
       "colors"
       "extends"
       "skip_output"
       "source_dir"
       "source_dir_local"
     ];
-    stages = l.attrNames (l.removeAttrs d skip_attrs);
-    stagesStr = l.concatStringsSep " " stages;
-  in ''
-    # Install configured hooks
-    for stage in ${stagesStr}; do
-      ${l.getExe nixpkgs.lefthook} add -f "$stage"
-    done
-  '';
+in {
+  data = {};
+  format = "yaml";
+  output = "lefthook.yml";
+  packages = [nixpkgs.lefthook];
+  # Add an extra hook for adding required stages whenever the file changes
+  hook.extra = config:
+    lib.pipe config [
+      toStagesConfig
+      lib.attrNames
+      (lib.map (stage: ''ln -sf "${mkScript stage}" ".git/hooks/${stage}"''))
+      (stages:
+        lib.optional (stages != []) "mkdir -p .git/hooks"
+        ++ stages)
+      (lib.concatStringsSep "\n")
+    ];
 }


### PR DESCRIPTION
this helps with running hooks outside the devshell, for example:
- Jetbrains IDE's Commit dialog

for completeness' sake also updated all dependencies switching to direct paths instead of command invocations