### PR TITLE
fix uid/gid in OCI user

### DIFF
--- a/src/lib/ops/mkStandardOCI.nix
+++ b/src/lib/ops/mkStandardOCI.nix
@@ -88,10 +88,9 @@ in
       '';
 
     users = cell.ops.mkUser {
+      inherit uid gid;
       user = "nobody";
       group = "nogroup";
-      uid = "65534";
-      gid = "65534";
       withRoot = true;
       withHome = true;
     };


### PR DESCRIPTION
I have found that uid and gid parameters in mkStandardOCI function was being ignored. I hope this fix will be enough.