### PR TITLE
feat: make terra plan write diff to github PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   mac:
     uses: ./.github/workflows/std.yml
     with:
-      runs-on: macOS-12
+      runs-on: macOS-13
     secrets: inherit
 
   linux:

--- a/src/local/flake.lock
+++ b/src/local/flake.lock
@@ -364,13 +364,13 @@
         "yants": "yants"
       },
       "locked": {
-        "lastModified": 1,
-        "narHash": "sha256-R+kgZygzHmVjdN64mJqNzZd8wj2wW4goAGb9bfrnnGk=",
-        "path": "/nix/store/w579nzy4r8siqn3xv5qh17qw0463jp6i-source",
+        "lastModified": 0,
+        "narHash": "sha256-XnaA3tCS63IMY04wTMqJ5EX47X0fDM9J+0dg6TxXvz8=",
+        "path": "/nix/store/5pmjinxmq96n3k708s8qii01awbr9w09-source",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/w579nzy4r8siqn3xv5qh17qw0463jp6i-source",
+        "path": "/nix/store/5pmjinxmq96n3k708s8qii01awbr9w09-source",
         "type": "path"
       }
     },

--- a/src/std/fwlib/blockTypes/_postDiffToGitHubSnippet.nix
+++ b/src/std/fwlib/blockTypes/_postDiffToGitHubSnippet.nix
@@ -1,0 +1,73 @@
+_: path: cmd: script: ''
+
+  if [[ -v CI ]] && [[ -v BRANCH ]] && [[ -v OWNER_AND_REPO ]] && command -v gh > /dev/null ; then
+
+    OWNER_REPO_NAME=$(gh repo view "$OWNER_AND_REPO" --json nameWithOwner --jq '.nameWithOwner')
+
+    if ! gh pr view "$BRANCH" --repo "$OWNER_REPO_NAME" >/dev/null 2>&1; then
+      exit 0
+    fi
+
+    set +e # diff exits 1 if diff existed
+    DIFF_OUTPUT=$(${script})
+    set -e
+
+    if [[ -z "$DIFF_OUTPUT" ]]; then
+      exit 0
+    fi
+
+    CENTRAL_COMMENT_HEADER="<!-- Unified Diff Comment -->"
+    ENTRY_START_MARKER="<!-- Start Diff for ${path}:${cmd} -->"
+    ENTRY_END_MARKER="<!-- End Diff for ${path}:${cmd} -->"
+
+    DIFF_ENTRY=$(cat <<EOF
+
+$ENTRY_START_MARKER
+<details>
+<summary>//${path}:${cmd}</summary>
+
+\`\`\`diff
+$DIFF_OUTPUT
+\`\`\`
+
+</details>
+$ENTRY_END_MARKER
+EOF
+    )
+
+    PR_NUMBER=$(gh pr view "$BRANCH" --repo "$OWNER_REPO_NAME" --json number --jq '.number')
+
+    EXISTING_COMMENT_ID=$(gh api "repos/$OWNER_REPO_NAME/issues/$PR_NUMBER/comments?per_page=100" --jq ".[] | select(.body | contains(\"$CENTRAL_COMMENT_HEADER\")) | .id" | head -n 1)
+
+    if [[ -n "$EXISTING_COMMENT_ID" ]]; then
+      EXISTING_BODY=$(gh api "repos/$OWNER_REPO_NAME/issues/comments/$EXISTING_COMMENT_ID" --jq '.body')
+
+      if echo "$EXISTING_BODY" | grep -q "$ENTRY_START_MARKER"; then
+        UPDATED_BODY=$(echo "$EXISTING_BODY" | sed -e "\#$ENTRY_START_MARKER#,\#$ENTRY_END_MARKER#d")
+      else
+        UPDATED_BODY="$EXISTING_BODY"
+      fi
+
+      UPDATED_BODY="$UPDATED_BODY
+$DIFF_ENTRY"
+
+      echo "Make an edit post ..."
+      gh api --method PATCH "repos/$OWNER_REPO_NAME/issues/comments/$EXISTING_COMMENT_ID" -f body="$UPDATED_BODY" --jq '.html_url'
+
+    else
+      NEW_COMMENT=$(cat <<EOF
+$CENTRAL_COMMENT_HEADER
+## DiffPost
+
+This PR includes the following diffs:
+$DIFF_ENTRY
+EOF
+      )
+      echo "Make a first post ..."
+      gh pr comment "$PR_NUMBER" --repo "$OWNER_REPO_NAME" --body "$NEW_COMMENT"
+    fi
+
+    exit 0
+
+  fi
+''

--- a/src/std/fwlib/blockTypes/kubectl.nix
+++ b/src/std/fwlib/blockTypes/kubectl.nix
@@ -16,7 +16,7 @@ Available actions:
 */
 let
   inherit (root) mkCommand;
-  inherit (super) addSelectorFunctor askUserToProceedSnippet;
+  inherit (super) addSelectorFunctor askUserToProceedSnippet postDiffToGitHubSnippet;
 in
   name: {
     __functor = addSelectorFunctor;
@@ -137,34 +137,11 @@ in
         } "$manifest_path/";
         }
 
-        # GitHub case
-        if [[ -v CI ]] && [[ -v BRANCH ]] && [[ -v OWNER_AND_REPO ]] && command gh > /dev/null ; then
+        ${postDiffToGitHubSnippet fragmentRelPath "kubectl" "diff"}
 
-          set +e # diff exits 1 if diff existed
-          read -r -d "" DIFFSTREAM <<DIFF
-        ## Standard DiffPost
-
-        This PR would generate the following \`kubectl\` diff:
-
-        <details><summary>Preview</summary>
-
-        \`\`\`diff
-        $(diff)
-        \`\`\`
-
-        </details>
-        DIFF
-          set -e # we're past the invocation of diff
-
-          if ! gh pr --repo "$OWNER_AND_REPO" comment "$BRANCH" --edit-last -b "$DIFFSTREAM"; then
-            echo "Make a first post ..."
-            gh pr --repo "$OWNER_AND_REPO" comment "$BRANCH" -b "$DIFFSTREAM"
-          fi
-        else
-          KUBECTL_EXTERNAL_DIFF="icdiff -N -r"
-          export KUBECTL_EXTERNAL_DIFF
-          diff
-        fi
+        KUBECTL_EXTERNAL_DIFF="icdiff -N -r"
+        export KUBECTL_EXTERNAL_DIFF
+        diff
       '' {})
       (mkCommand currentSystem "apply" "Apply the manifests to K8s" [pkgs.kubectl pkgs.icdiff] ''
         ${build}

--- a/src/std/fwlib/blockTypes/kubectl.nix
+++ b/src/std/fwlib/blockTypes/kubectl.nix
@@ -137,7 +137,7 @@ in
         } "$manifest_path/";
         }
 
-        ${postDiffToGitHubSnippet fragmentRelPath "kubectl" "diff"}
+        ${postDiffToGitHubSnippet "${fragmentRelPath}:diff" "$(diff || true)" "<code>std ${fragmentRelPath}:diff</code>"}
 
         KUBECTL_EXTERNAL_DIFF="icdiff -N -r"
         export KUBECTL_EXTERNAL_DIFF

--- a/src/std/fwlib/blockTypes/nvfetcher.nix
+++ b/src/std/fwlib/blockTypes/nvfetcher.nix
@@ -40,7 +40,7 @@ in
            --changelog "$tmpfile" \
            --filter "^$targetname$"
 
-        sed -i -e "s|^|- \`$(date --iso-8601=m)\` |" "$tmpfile"
+        sed -i '''' -e "s|^|- \`$(date --iso-8601=m)\` |" "$tmpfile"
         cat "$tmpfile" >> "$updates"
       '' {})
     ];

--- a/src/tests/flake.lock
+++ b/src/tests/flake.lock
@@ -358,17 +358,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1685739139,
-        "narHash": "sha256-CLGEW11Fo1v4vj0XSqiyW1EbhRZFO7dkgM43eKwItrk=",
+        "lastModified": 1723542174,
+        "narHash": "sha256-qI1C854yrNLWlpsnd4bARk6ajp9z0rhBl1EF0Aew6gs=",
         "owner": "nix-community",
         "repo": "namaka",
-        "rev": "d9a2cc83c1d0f68bd613f1fc909d0ef2cfffcf2e",
+        "rev": "ecefdd6d1e0e075403a69202c2695f966ea2f412",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "v0.2.0",
         "repo": "namaka",
+        "rev": "ecefdd6d1e0e075403a69202c2695f966ea2f412",
         "type": "github"
       }
     },
@@ -538,13 +538,13 @@
         "yants": "yants"
       },
       "locked": {
-        "lastModified": 1,
-        "narHash": "sha256-4jz2Kz+zKEbGJnpnE5PUqWp2GAthNhP+zIC8wLJqn28=",
-        "path": "/nix/store/ilww27xvk5605hxhx8b6xlw14ky4qhrp-source",
+        "lastModified": 0,
+        "narHash": "sha256-fiGxfoXDVBJzBLpoxPwdM/AcRq/dNIeZLNrMqgmuhNk=",
+        "path": "/nix/store/b0qrhagsdpgyw9hx9wzrszwsdg5wfnnd-source",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/ilww27xvk5605hxhx8b6xlw14ky4qhrp-source",
+        "path": "/nix/store/b0qrhagsdpgyw9hx9wzrszwsdg5wfnnd-source",
         "type": "path"
       }
     },

--- a/src/tests/flake.nix
+++ b/src/tests/flake.nix
@@ -13,7 +13,7 @@
     terranix.inputs.terranix-examples.follows = "";
     terranix.inputs.bats-support.follows = "";
     terranix.inputs.bats-assert.follows = "";
-    namaka.url = "github:nix-community/namaka/v0.2.0";
+    namaka.url = "github:nix-community/namaka/ecefdd6d1e0e075403a69202c2695f966ea2f412";
     namaka.inputs.haumea.follows = "std/haumea";
     namaka.inputs.nixpkgs.follows = "std/nixpkgs";
     makes.url = "github:fluidattacks/makes";

--- a/tests/_snapshots/check-augmented-cell-inputs
+++ b/tests/_snapshots/check-augmented-cell-inputs
@@ -12,7 +12,7 @@
   makes = "/nix/store/71rzg7vs53gmxqph64d9zqf4ns928c6c-source";
   microvm = "/nix/store/v5za7dzczgcvfvqgcm80qari3msyhw6b-source";
   n2c = "/nix/store/rgd4s5ylv38p94wi6vays6wc1a0l5iyf-source";
-  namaka = "/nix/store/xgzvi3baaaz9lpymfv6f1fgxfmy0ygvv-source";
+  namaka = "/nix/store/prb836vl3r64l97045clfli0d5m5fyap-source";
   nixago = "/nix/store/cys15p6lyyhj85bk4bckn82waih2l945-source";
   nixpkgs = "/nix/store/g8zzlf6drg73c987ii390yicq4c0j778-source";
   paisano = "/nix/store/4v8nn2z2vl74yz1557n1dha3l7rzzbgs-source";


### PR DESCRIPTION
Introduce `postDiffToGitHubSnippet` for unified diff posting and update `kubectl.nix` and `terra.nix`

- **Add `postDiffToGitHubSnippet`:**
  - Created a reusable snippet that handles posting unified diffs to GitHub PR comments using the `gh` CLI.
  - Manages existing comments by updating them or creates new ones if necessary.

- **Update `kubectl.nix`:**
  - Replaced inline diff posting logic with the new `postDiffToGitHubSnippet`.

- **Modify `terra.nix`:**
  - Integrated `postDiffToGitHubSnippet` into the `plan` command within the `wrap` function.
  - Exported `TF_VAR_fragment` and `TF_VAR_fragmentRelPath` for use in Terraform configurations.
  - Changed the Terraform working directory to `$PRJ_ROOT/.cache/${fragmentRelPath}/.tf` for better organization.