### PR TITLE
fix!: oci perms

### DIFF
--- a/src/lib/ops/mkSetup.nix
+++ b/src/lib/ops/mkSetup.nix
@@ -15,7 +15,6 @@ in
   */
   name: perms: contents: let
     setup = nixpkgs.runCommand "oci-setup-${name}" {} contents;
-    perms' = l.map (p: p // {path = setup;}) perms;
   in
     setup
-    // l.optionalAttrs (perms != []) {passthru.perms = perms';}
+    // l.optionalAttrs (perms != []) {passthru = {inherit perms;};}


### PR DESCRIPTION
existing users of `config.copyToRoot` quite likely need to hove the contents of this key to `setup = [];` &mdash; `config.copyToRoot` may prime the nix2container permission cache with a parent folder (e.g. `/bin`) and conflicting permissions