### PR TITLE
fix: update flake & subflakes lockfiles, fix test

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669263024,
-        "narHash": "sha256-E/+23NKtxAqYG/0ydYgxlgarKnxmDbg6rCMWnOBqn9Q=",
+        "lastModified": 1693483555,
+        "narHash": "sha256-Beq4WhSeH3jRTZgC1XopTSU10yLpK1nmMcnGoXO0XYo=",
         "owner": "divnix",
         "repo": "incl",
-        "rev": "ce7bebaee048e4cd7ebdb4cee7885e00c4e2abca",
+        "rev": "526751ad3d1e23b07944b14e3f6b7a5948d3007b",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "lib": {
       "locked": {
-        "lastModified": 1694306727,
-        "narHash": "sha256-26fkTOJOI65NOTNKFvtcJF9mzzf/kK9swHzfYt1Dl6Q=",
+        "lastModified": 1722128034,
+        "narHash": "sha256-L8rwzYPsLo/TYtydPJoQyYOfetuiyQYnTWYcyB8UE/s=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "c30b6a84c0b84ec7aecbe74466033facc9ed103f",
+        "rev": "d15f6f6021693898fcd2c6a9bb13707383da9bbc",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708343346,
-        "narHash": "sha256-qlzHvterVRzS8fS0ophQpkh0rqw0abijHEOAKm0HmV0=",
+        "lastModified": 1720535198,
+        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9312b935a538684049cb668885e60f15547d4c5f",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
         "type": "github"
       },
       "original": {

--- a/src/local/flake.lock
+++ b/src/local/flake.lock
@@ -142,11 +142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669263024,
-        "narHash": "sha256-E/+23NKtxAqYG/0ydYgxlgarKnxmDbg6rCMWnOBqn9Q=",
+        "lastModified": 1693483555,
+        "narHash": "sha256-Beq4WhSeH3jRTZgC1XopTSU10yLpK1nmMcnGoXO0XYo=",
         "owner": "divnix",
         "repo": "incl",
-        "rev": "ce7bebaee048e4cd7ebdb4cee7885e00c4e2abca",
+        "rev": "526751ad3d1e23b07944b14e3f6b7a5948d3007b",
         "type": "github"
       },
       "original": {
@@ -157,11 +157,11 @@
     },
     "lib": {
       "locked": {
-        "lastModified": 1694306727,
-        "narHash": "sha256-26fkTOJOI65NOTNKFvtcJF9mzzf/kK9swHzfYt1Dl6Q=",
+        "lastModified": 1722128034,
+        "narHash": "sha256-L8rwzYPsLo/TYtydPJoQyYOfetuiyQYnTWYcyB8UE/s=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "c30b6a84c0b84ec7aecbe74466033facc9ed103f",
+        "rev": "d15f6f6021693898fcd2c6a9bb13707383da9bbc",
         "type": "github"
       },
       "original": {
@@ -243,11 +243,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708343346,
-        "narHash": "sha256-qlzHvterVRzS8fS0ophQpkh0rqw0abijHEOAKm0HmV0=",
+        "lastModified": 1720535198,
+        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9312b935a538684049cb668885e60f15547d4c5f",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
         "type": "github"
       },
       "original": {
@@ -364,13 +364,13 @@
         "yants": "yants"
       },
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-xVvvc7GVV1K0E4jcNyq2YIlgbdiEeZQa5/Lw2qr/EAI=",
-        "path": "/nix/store/zbfzfy7l2av5b3ddnrcf1grn04863ffd-source",
+        "lastModified": 1,
+        "narHash": "sha256-R+kgZygzHmVjdN64mJqNzZd8wj2wW4goAGb9bfrnnGk=",
+        "path": "/nix/store/w579nzy4r8siqn3xv5qh17qw0463jp6i-source",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/zbfzfy7l2av5b3ddnrcf1grn04863ffd-source",
+        "path": "/nix/store/w579nzy4r8siqn3xv5qh17qw0463jp6i-source",
         "type": "path"
       }
     },

--- a/src/tests/flake.lock
+++ b/src/tests/flake.lock
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669263024,
-        "narHash": "sha256-E/+23NKtxAqYG/0ydYgxlgarKnxmDbg6rCMWnOBqn9Q=",
+        "lastModified": 1693483555,
+        "narHash": "sha256-Beq4WhSeH3jRTZgC1XopTSU10yLpK1nmMcnGoXO0XYo=",
         "owner": "divnix",
         "repo": "incl",
-        "rev": "ce7bebaee048e4cd7ebdb4cee7885e00c4e2abca",
+        "rev": "526751ad3d1e23b07944b14e3f6b7a5948d3007b",
         "type": "github"
       },
       "original": {
@@ -268,11 +268,11 @@
     },
     "lib": {
       "locked": {
-        "lastModified": 1694306727,
-        "narHash": "sha256-26fkTOJOI65NOTNKFvtcJF9mzzf/kK9swHzfYt1Dl6Q=",
+        "lastModified": 1722128034,
+        "narHash": "sha256-L8rwzYPsLo/TYtydPJoQyYOfetuiyQYnTWYcyB8UE/s=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "c30b6a84c0b84ec7aecbe74466033facc9ed103f",
+        "rev": "d15f6f6021693898fcd2c6a9bb13707383da9bbc",
         "type": "github"
       },
       "original": {
@@ -397,11 +397,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708343346,
-        "narHash": "sha256-qlzHvterVRzS8fS0ophQpkh0rqw0abijHEOAKm0HmV0=",
+        "lastModified": 1720535198,
+        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9312b935a538684049cb668885e60f15547d4c5f",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
         "type": "github"
       },
       "original": {
@@ -538,13 +538,13 @@
         "yants": "yants"
       },
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-PxFT7JDiDyDVS9mJfZiAeNBBTHY07a9Si7XhZ0UlSxk=",
-        "path": "/nix/store/f6ybcd8kfg19y5pwhp0s7ljplzk87v4q-source",
+        "lastModified": 1,
+        "narHash": "sha256-4jz2Kz+zKEbGJnpnE5PUqWp2GAthNhP+zIC8wLJqn28=",
+        "path": "/nix/store/ilww27xvk5605hxhx8b6xlw14ky4qhrp-source",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/f6ybcd8kfg19y5pwhp0s7ljplzk87v4q-source",
+        "path": "/nix/store/ilww27xvk5605hxhx8b6xlw14ky4qhrp-source",
         "type": "path"
       }
     },

--- a/tests/_snapshots/check-augmented-cell-inputs
+++ b/tests/_snapshots/check-augmented-cell-inputs
@@ -7,14 +7,14 @@
   dmerge = "/nix/store/8b67fxqldqv1x3x07nhabb9ild2zl6rz-source";
   flake-parts = "/nix/store/jiyanhix45y0a7m9nsrng44yjzrp79m9-source";
   haumea = "/nix/store/ih873qmabdsdgk1naaiv6v7jy1mxq241-source";
-  incl = "/nix/store/4dqlpd9c8yil4ay4prr38vslxhpsp4zp-source";
-  lib = "/nix/store/2rv5rbn68fjpc2lhs7wyxyisa4vyxn6a-source";
+  incl = "/nix/store/9yriyvqkcvhqwizwdbsblk3pp0dkgim2-source";
+  lib = "/nix/store/0vvdgp2wdj9q0kqgakgax3bwhkd152rx-source";
   makes = "/nix/store/71rzg7vs53gmxqph64d9zqf4ns928c6c-source";
   microvm = "/nix/store/v5za7dzczgcvfvqgcm80qari3msyhw6b-source";
   n2c = "/nix/store/rgd4s5ylv38p94wi6vays6wc1a0l5iyf-source";
   namaka = "/nix/store/xgzvi3baaaz9lpymfv6f1fgxfmy0ygvv-source";
   nixago = "/nix/store/cys15p6lyyhj85bk4bckn82waih2l945-source";
-  nixpkgs = "/nix/store/63dmz0d1a6fsqcnrk3bn7vwsyjx3w34l-source";
+  nixpkgs = "/nix/store/g8zzlf6drg73c987ii390yicq4c0j778-source";
   paisano = "/nix/store/4v8nn2z2vl74yz1557n1dha3l7rzzbgs-source";
   paisano-tui = "/nix/store/rdrvzcs8j77fccnkky6p2sagc0d49hyy-source";
   terranix = "/nix/store/agasgh0qgqi0fxk3zzgrjvqpx6k8036c-source";


### PR DESCRIPTION
fixes #385 - Broken `nix flake show` command.

update flake inputs:

- `flake.lock`
- `src/local/flake.lock`
- `src/tests/flake.lock`

update store paths in tests:

- `tests/_snapshots/check-augmented-cell-inputs`