### PR TITLE
fix: treefmt on nixos-unstable

### DIFF
--- a/src/data/configs/lefthook.nix
+++ b/src/data/configs/lefthook.nix
@@ -17,7 +17,7 @@ in {
     pre-commit = {
       commands = {
         treefmt = {
-          run = "${lib.getExe nixpkgs.treefmt1 or nixpkgs.treefmt} --fail-on-change {staged_files}";
+          run = "${lib.getExe nixpkgs.treefmt} --fail-on-change {staged_files}";
           skip = ["merge" "rebase"];
         };
       };

--- a/src/lib/cfg/treefmt.nix
+++ b/src/lib/cfg/treefmt.nix
@@ -4,5 +4,5 @@ in {
   data = {};
   output = "treefmt.toml";
   format = "toml";
-  commands = [{package = nixpkgs.treefmt1 or nixpkgs.treefmt;}];
+  commands = [{package = nixpkgs.treefmt;}];
 }


### PR DESCRIPTION
[nixpkgs@dcb250a](https://github.com/NixOS/nixpkgs/commit/dcb250aecc47ed727521bd9d62e23861e8b64bdf) introduced some changes to the `treefmt` package:
- the `treefmt` package is `treefmt v2` aka the go version)
- the `treefmt1` package throws an eval error

resulting in broken `std devens` as they trigger the eval error for `treefmt1`.

[std@febf2ee](https://github.com/divnix/std/commit/febf2ee06d6a5beeff1e1807e1348f497fffb14e) explicitly selects the discontinued rust implementation due to unfixed bugs in 24.11 for treefmt < 2.1.1.

The `std` repo still uses the `23.11` nixpkgs release.

@blaggacao I'm not sure what the best path forward is for this change to not break backwards compatibility, please advise.

Until this is sorted I'll leave this PR as draft for further discussion.