### PR TITLE
fix: balance nvfetcher script quotes

### DIFF
--- a/src/std/fwlib/blockTypes/nvfetcher.nix
+++ b/src/std/fwlib/blockTypes/nvfetcher.nix
@@ -40,7 +40,7 @@ in
            --changelog "$tmpfile" \
            --filter "^$targetname$"
 
-        sed -i '''' -e "s|^|- \`$(date --iso-8601=m)\` |" "$tmpfile"
+        sed -i ''' -e "s|^|- \`$(date --iso-8601=m)\` |" "$tmpfile"
         cat "$tmpfile" >> "$updates"
       '' {})
     ];


### PR DESCRIPTION
As stated on the documentation.

> '' is escaped by prefixing it with one single quote (')