### PR TITLE
Disable errexit for kubectl diff

### DIFF
--- a/src/std/fwlib/blockTypes/kubectl.nix
+++ b/src/std/fwlib/blockTypes/kubectl.nix
@@ -151,11 +151,13 @@ in
         export KUBECTL_EXTERNAL_DIFF
 
         diff() {
+          set +o errexit
           kubectl diff --server-side=true --field-manager="std-action-$(whoami)" ${
           if usesKustomize
           then "--kustomize"
           else "--recursive --filename"
         } "$manifest_path/";
+          set -o errexit
 
           return $?;
         }


### PR DESCRIPTION
Greetings @blaggacao, find the github actions exit unexpectedly after running the kubectl diff command.
# Problem
When there is difference `kubectl diff` will return exit status 1. If we have `set -o errexit` the script will exit after that command.
# Solution
Wrap `kubectl diff` command with following
```sh
set +o errexit
kubectl diff ...
set -o errexit
```