### PR TITLE
Pass down $@ to the copy function in the container's publish command

### DIFF
--- a/src/std/fwlib/blockTypes/containers.nix
+++ b/src/std/fwlib/blockTypes/containers.nix
@@ -62,7 +62,7 @@ in
       '' {})
       (mkCommand currentSystem "publish" "copy the image to its remote registry" [skopeo-nix2container] ''
           ${copyFn}
-          copy docker://${target.image.repo}
+          copy docker://${target.image.repo} "$@"
         '' {
           meta.image = target.image.name;
           inherit proviso;


### PR DESCRIPTION
It seems to be an oversight since the `:load` command does pass down the remaining arguments.

My use case is that I want to be able to add all the flags related to authentication.